### PR TITLE
New observer role for scoped access to gamespace audiences

### DIFF
--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceController.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceController.cs
@@ -70,7 +70,7 @@ namespace TopoMojo.Api.Controllers
             AuthorizeAll();
 
             return Ok(
-                await _svc.List(model, Actor.Id, Actor.IsAdmin, ct)
+                await _svc.List(model, Actor.Id, Actor.IsAdmin, Actor.IsObserver, Actor.Scope, ct)
             );
         }
 
@@ -122,14 +122,15 @@ namespace TopoMojo.Api.Controllers
 
         [HttpGet("api/gamespace/{id}/challenge")]
         [SwaggerOperation(OperationId = "LoadGamespaceChallenge")]
-        [Authorize(AppConstants.AdminOnlyPolicy)]
+        [Authorize]
         [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<ActionResult<ChallengeSpec>> LoadChallenge(string id)
         {
             await Validate(new Entity { Id = id });
 
             AuthorizeAny(
-                () => Actor.IsAdmin
+                () => Actor.IsAdmin,
+                () => Actor.IsObserver && _svc.HasValidUserScopeGamespace(id, Actor.Scope).Result 
             );
 
             return Ok(

--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
@@ -49,11 +49,12 @@ namespace TopoMojo.Api.Services
         private readonly Random _random;
         private readonly IDistributedCache _distCache;
 
-        public async Task<Gamespace[]> List(GamespaceSearch search, string subjectId, bool sudo, CancellationToken ct = default(CancellationToken))
+        public async Task<Gamespace[]> List(GamespaceSearch search, string subjectId, bool sudo, bool observer, string scope, CancellationToken ct = default(CancellationToken))
         {
-            var query =  (sudo && search.WantsAll)
-                ? _store.List(search.Term)
-                : _store.ListByUser(subjectId)
+            
+            var query = (observer && search.WantsAll)
+                ? _store.List(search.Term) // dashboard list - admin or observer
+                : _store.ListByUser(subjectId) // side panel browser - anyone
             ;
 
             if (search.WantsActive)
@@ -73,9 +74,21 @@ namespace TopoMojo.Api.Services
             if (search.Take > 0)
                 query = query.Take(search.Take);
 
-            return Mapper.Map<Gamespace[]>(
-                await query.ToArrayAsync()
-            );
+            query = query.Include(g => g.Workspace);
+
+            var data = await query.ToArrayAsync();
+            
+            // filter only when user is observer (but not admin)
+            // select gamespaces with matching workspace audience / user scope
+            if (search.WantsAll && observer && !sudo)
+            { 
+                // complex string splitting done after all querying completed
+                data = data
+                    .Where(g => g.Workspace.Audience.HasAnyToken(scope)) 
+                    .ToArray();
+            }
+
+            return Mapper.Map<Gamespace[]>(data);
         }
 
         public async Task<GameState> Preview(string resourceId)
@@ -916,6 +929,13 @@ namespace TopoMojo.Api.Services
             scope += " " + _options.DefaultUserScope;
 
             return await _store.HasValidUserScope(id, scope, subjectId);
+        }
+
+        public async Task<bool> HasValidUserScopeGamespace(string id, string scope)
+        {
+            scope += " " + _options.DefaultUserScope;
+
+            return await _store.HasValidUserScopeGamespace(id, scope);
         }
     }
 }

--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceStore.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceStore.cs
@@ -129,6 +129,16 @@ namespace TopoMojo.Api.Data
             ;
         }
 
+        public async Task<bool> HasValidUserScopeGamespace(string gamespaceId, string scope)
+        {
+            var gamespace = await DbContext.Gamespaces
+                .Where(g => g.Id == gamespaceId)
+                .Include( g => g.Workspace)
+                .FirstOrDefaultAsync();
+
+            return gamespace.Workspace.Audience.HasAnyToken(scope);
+        }
+
         public async Task<bool> IsBelowGamespaceLimit(string subjectId, int limit)
         {
             if (limit == 0)

--- a/src/TopoMojo.Api/Features/Gamespace/IGamespaceStore.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/IGamespaceStore.cs
@@ -18,6 +18,7 @@ namespace TopoMojo.Api.Data.Abstractions
         Task<bool> CanInteract(string id, string subjectId);
         Task<bool> CanManage(string id, string subjectId);
         Task<bool> HasValidUserScope(string id, string scope, string subjectId);
+        Task<bool> HasValidUserScopeGamespace(string gamespaceId, string scope);
         Task<bool> IsBelowGamespaceLimit(string id, int gamespaceLimit);
     }
 }

--- a/src/TopoMojo.Api/Features/User/IUserStore.cs
+++ b/src/TopoMojo.Api/Features/User/IUserStore.cs
@@ -9,6 +9,7 @@ namespace TopoMojo.Api.Data.Abstractions
     public interface IUserStore : IStore<User>
     {
         Task<bool> CanInteract(string id, string isolationId);
+        Task<bool> CanInteractWithAudience(string scope, string gamespaceId);
         Task<User> LoadWithKeys(string id);
         Task<User> ResolveApiKey(string hash);
         Task DeleteApiKey(string id);

--- a/src/TopoMojo.Api/Features/User/UserModels.cs
+++ b/src/TopoMojo.Api/Features/User/UserModels.cs
@@ -62,6 +62,7 @@ namespace TopoMojo.Api.Models
     public class UserSearch: Search
     {
         public bool WantsAdmins => Filter.Contains(UserRole.Administrator.ToString().ToLower());
+        public bool WantsObservers => Filter.Contains(UserRole.Observer.ToString().ToLower());
         public bool WantsCreators => Filter.Contains(UserRole.Creator.ToString().ToLower());
         public bool WantsBuilders => Filter.Contains(UserRole.Builder.ToString().ToLower());
         public string scope { get; set; }

--- a/src/TopoMojo.Api/Features/User/UserModels.cs
+++ b/src/TopoMojo.Api/Features/User/UserModels.cs
@@ -12,7 +12,8 @@ namespace TopoMojo.Api.Models
         Builder,
         Creator,
         Administrator,
-        Disabled
+        Disabled,
+        Observer
     }
 
     public class User
@@ -29,13 +30,19 @@ namespace TopoMojo.Api.Models
         public bool IsAdmin =>
             Role == UserRole.Administrator
         ;
+        public bool IsObserver => 
+            Role == UserRole.Observer ||
+            Role == UserRole.Administrator
+        ;
         public bool IsCreator =>
             Role == UserRole.Creator ||
+            Role == UserRole.Observer ||
             Role == UserRole.Administrator
         ;
         public bool IsBuilder =>
             Role == UserRole.Builder ||
             Role == UserRole.Creator ||
+            Role == UserRole.Observer ||
             Role == UserRole.Administrator
         ;
     }

--- a/src/TopoMojo.Api/Features/User/UserService.cs
+++ b/src/TopoMojo.Api/Features/User/UserService.cs
@@ -47,6 +47,9 @@ namespace TopoMojo.Api.Services
 
             if (search.WantsAdmins)
                 q = q.Where(p => p.Role == UserRole.Administrator);
+            
+            if (search.WantsObservers)
+                q = q.Where(p => p.Role == UserRole.Observer);
 
             if (search.WantsCreators)
                 q = q.Where(p => p.Role == UserRole.Creator);
@@ -55,7 +58,7 @@ namespace TopoMojo.Api.Services
                 q = q.Where(p => p.Role == UserRole.Builder);
 
             if (search.scope.NotEmpty())
-                q = q.Where(p => p.Scope == search.scope);
+                q = q.Where(p => p.Scope.Contains(search.scope));
 
             q = q.OrderBy(p => p.Name);
 

--- a/src/TopoMojo.Api/Features/User/UserService.cs
+++ b/src/TopoMojo.Api/Features/User/UserService.cs
@@ -165,6 +165,11 @@ namespace TopoMojo.Api.Services
             return await _store.CanInteract(subjectId, isolationId);
         }
 
+        public async Task<bool> CanInteractWithAudience(string subjectId, string isolationId)
+        {
+            return await _store.CanInteractWithAudience(subjectId, isolationId);
+        }
+
         public async Task<ApiKeyResult> CreateApiKey(string id, string subjectName)
         {
             var entity = await _store.Retrieve(id);

--- a/src/TopoMojo.Api/Features/User/UserStore.cs
+++ b/src/TopoMojo.Api/Features/User/UserStore.cs
@@ -66,6 +66,20 @@ namespace TopoMojo.Api.Data
             return found;
         }
 
+        public async Task<bool> CanInteractWithAudience(string scope, string gamespaceId)
+        {
+            if (gamespaceId.IsEmpty())
+                return false;
+
+            var gamespace = await DbContext.Gamespaces
+                .Include(g => g.Workspace)
+                .FirstOrDefaultAsync(g =>
+                    g.Id == gamespaceId
+                );
+
+            return gamespace.Workspace.Audience.HasAnyToken(scope);
+        }
+
         public Task<User> LoadWithKeys(string id)
         {
             return DbSet


### PR DESCRIPTION
Corresponding backend changes for https://github.com/cmu-sei/topomojo-ui/pull/7

- New user role type `Observer`
- Observers now can list and interact with gamespaces that have an audience tag that matches the user's scope tag
- Modified queries based on role and scope/audience overlap
- New authorize checks based on role and scope/audience overlap