### PR TITLE
Authorization for audience match support gamespace or workspace id

### DIFF
--- a/src/TopoMojo.Api/Features/User/IUserStore.cs
+++ b/src/TopoMojo.Api/Features/User/IUserStore.cs
@@ -9,7 +9,7 @@ namespace TopoMojo.Api.Data.Abstractions
     public interface IUserStore : IStore<User>
     {
         Task<bool> CanInteract(string id, string isolationId);
-        Task<bool> CanInteractWithAudience(string scope, string gamespaceId);
+        Task<bool> CanInteractWithAudience(string scope, string isolationId);
         Task<User> LoadWithKeys(string id);
         Task<User> ResolveApiKey(string hash);
         Task DeleteApiKey(string id);

--- a/src/TopoMojo.Api/Features/User/UserStore.cs
+++ b/src/TopoMojo.Api/Features/User/UserStore.cs
@@ -66,18 +66,27 @@ namespace TopoMojo.Api.Data
             return found;
         }
 
-        public async Task<bool> CanInteractWithAudience(string scope, string gamespaceId)
+        public async Task<bool> CanInteractWithAudience(string scope, string isolationId)
         {
-            if (gamespaceId.IsEmpty())
+            if (isolationId.IsEmpty())
                 return false;
 
             var gamespace = await DbContext.Gamespaces
                 .Include(g => g.Workspace)
                 .FirstOrDefaultAsync(g =>
-                    g.Id == gamespaceId
+                    g.Id == isolationId
                 );
-
-            return gamespace.Workspace.Audience.HasAnyToken(scope);
+            if (gamespace != null)
+                return gamespace.Workspace.Audience.HasAnyToken(scope);
+            
+            var workspace = await DbContext.Workspaces
+                .FirstOrDefaultAsync(g =>
+                    g.Id == isolationId
+                );
+            if (workspace != null)
+                return workspace.Audience.HasAnyToken(scope);
+            
+            return false;
         }
 
         public Task<User> LoadWithKeys(string id)


### PR DESCRIPTION
The `IsolationId` passed to the authorize functions is used to check whether a user can manage a resource based on their role, management status, or audience/scope match. This id can be a `WorkspaceId` _or_ a `GamespaceId`. The newly added function `CanInteractWithAudience()` was only checking for `GamespaceId` and would error and not grant permission when passed a `WorkspaceId`.

This PR modifies that function to accept either type of id. 