### PR TITLE
Make InitializeVmTemplate() endpoint match service return type

### DIFF
--- a/src/TopoMojo.Api/Features/Vm/VmController.cs
+++ b/src/TopoMojo.Api/Features/Vm/VmController.cs
@@ -407,7 +407,7 @@ namespace TopoMojo.Api.Controllers
         [HttpPut("api/vm-template/{id}")]
         [SwaggerOperation(OperationId = "InitializeVmTemplate")]
         [Authorize]
-        public async Task<ActionResult<Vm>> InitializeVmTemplate(string id)
+        public async Task<ActionResult<int>> InitializeVmTemplate(string id)
         {
             VmTemplate template  = await _templateService.GetDeployableTemplate(id, null);
 


### PR DESCRIPTION
`CreateDisk()`service returns type `int`, but `InitializeVmTemplate()` was returning type `Vm`. The endpoint return type is changed to  `int` to be consistent with the service it calls. 

Related to UI bug fix: https://github.com/cmu-sei/topomojo-ui/pull/9
