### PR TITLE
Adds the Tags field to the workspace summary model

### DIFF
--- a/src/TopoMojo.Api/Features/Workspace/WorkspaceModels.cs
+++ b/src/TopoMojo.Api/Features/Workspace/WorkspaceModels.cs
@@ -30,6 +30,7 @@ namespace TopoMojo.Api.Models
         public string Name { get; set; }
         public string Slug => Name.ToSlug();
         public string Description { get; set; }
+        public string Tags { get; set; }
         public string Text { get; set; }
         public string Audience { get; set; }
         public string Author { get; set; }


### PR DESCRIPTION
Tags are exposed when calling `api/workspace/{id}`, but not when listing multiple workspace summaries with `api/workspaces`. 

Exposing tags when querying a list of workspaces is useful for external tools (e.g., Gameboard) to be able to search for workspaces with those tags in the user's scope.

