### PR TITLE
Proxmox - virtual network management

### DIFF
--- a/src/TopoMojo.Api/Features/Admin/JanitorService.cs
+++ b/src/TopoMojo.Api/Features/Admin/JanitorService.cs
@@ -199,5 +199,4 @@ namespace TopoMojo.Api.Services
         }
 
     }
-
 }

--- a/src/TopoMojo.Api/Startup.cs
+++ b/src/TopoMojo.Api/Startup.cs
@@ -94,7 +94,6 @@ namespace TopoMojo.Api
             // Configure Auth
             services.AddConfiguredAuthentication(Settings.Oidc);
             services.AddConfiguredAuthorization();
-
         }
 
         public void Configure(IApplicationBuilder app)

--- a/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
+++ b/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     services.AddSingleton<IHypervisorService, TopoMojo.Hypervisor.Proxmox.ProxmoxHypervisorService>();
                     services.AddSingleton<IProxmoxNameService, ProxmoxNameService>();
                     services.AddSingleton<IProxmoxVlanManager, ProxmoxVlanManager>();
+                    services.AddSingleton<IProxmoxVnetsClient, ProxmoxVnetsClient>();
                     services.AddSingleton<Random>(_ => Random.Shared);
                 }
                 else

--- a/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
+++ b/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
@@ -10,6 +10,7 @@ using TopoMojo.Api;
 using TopoMojo.Api.Data;
 using TopoMojo.Hypervisor;
 using TopoMojo.Api.Services;
+using TopoMojo.Hypervisor.Proxmox;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -19,7 +20,8 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddTopoMojo(
             this IServiceCollection services,
             CoreOptions options
-        ) {
+        )
+        {
 
             services.AddSingleton<CoreOptions>(_ => options);
 
@@ -80,25 +82,25 @@ namespace Microsoft.Extensions.DependencyInjection
             {
 
                 case "sqlserver":
-                // builder.Services.AddEntityFrameworkSqlServer();
-                services.AddDbContext<TopoMojoDbContext, TopoMojoDbContextSqlServer>(
-                    db => db.UseSqlServer(connstr, options => options.MigrationsAssembly(migrationAssembly))
-                );
-                break;
+                    // builder.Services.AddEntityFrameworkSqlServer();
+                    services.AddDbContext<TopoMojoDbContext, TopoMojoDbContextSqlServer>(
+                        db => db.UseSqlServer(connstr, options => options.MigrationsAssembly(migrationAssembly))
+                    );
+                    break;
 
                 case "postgresql":
-                // services.AddEntityFrameworkNpgsql();
-                services.AddDbContext<TopoMojoDbContext, TopoMojoDbContextPostgreSQL>(
-                    db => db.UseNpgsql(connstr, options => options.MigrationsAssembly(migrationAssembly))
-                );
-                break;
+                    // services.AddEntityFrameworkNpgsql();
+                    services.AddDbContext<TopoMojoDbContext, TopoMojoDbContextPostgreSQL>(
+                        db => db.UseNpgsql(connstr, options => options.MigrationsAssembly(migrationAssembly))
+                    );
+                    break;
 
                 default:
-                // services.AddEntityFrameworkInMemoryDatabase();
-                services.AddDbContext<TopoMojoDbContext, TopoMojoDbContextInMemory>(
-                    db => db.UseInMemoryDatabase(connstr)
-                );
-                break;
+                    // services.AddEntityFrameworkInMemoryDatabase();
+                    services.AddDbContext<TopoMojoDbContext, TopoMojoDbContextInMemory>(
+                        db => db.UseInMemoryDatabase(connstr)
+                    );
+                    break;
 
             }
 
@@ -138,6 +140,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (config.IsProxmox)
                 {
                     services.AddSingleton<IHypervisorService, TopoMojo.Hypervisor.Proxmox.ProxmoxHypervisorService>();
+                    services.AddSingleton<IProxmoxNameService, ProxmoxNameService>();
+                    services.AddSingleton<IProxmoxVnetService, ProxmoxVnetService>();
                     services.AddSingleton<Random>(_ => Random.Shared);
                 }
                 else

--- a/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
+++ b/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     services.AddSingleton<IHypervisorService, TopoMojo.Hypervisor.Proxmox.ProxmoxHypervisorService>();
                     services.AddSingleton<IProxmoxNameService, ProxmoxNameService>();
-                    services.AddSingleton<IProxmoxVnetService, ProxmoxVnetService>();
+                    services.AddSingleton<IProxmoxVlanManager, ProxmoxVlanManager>();
                     services.AddSingleton<Random>(_ => Random.Shared);
                 }
                 else

--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -119,7 +119,6 @@
 
 ## datastore path of public iso's
 # Pod__IsoStore =
-# Pod__NodeIsoStore = nfs
 
 ## datastore path of workspace folders and template disks
 # Pod__DiskStore =

--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -156,6 +156,10 @@
 # Pod__Sddc__AuthUrl =
 # Pod__Sddc__AuthTokenHeader = csp-auth-token
 
+## these settings currently only apply to Proxmox (not vSphere)
+# Pod__Vlan__ResetDebounceDuration = 1000
+# Pod__Vlan__ResetDebounceMaxDuration = 2000
+
 ####################
 ## Logging
 ####################

--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -119,6 +119,7 @@
 
 ## datastore path of public iso's
 # Pod__IsoStore =
+# Pod__NodeIsoStore = nfs
 
 ## datastore path of workspace folders and template disks
 # Pod__DiskStore =

--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -157,8 +157,8 @@
 # Pod__Sddc__AuthTokenHeader = csp-auth-token
 
 ## these settings currently only apply to Proxmox (not vSphere)
-# Pod__Vlan__ResetDebounceDuration = 1000
-# Pod__Vlan__ResetDebounceMaxDuration = 2000
+# Pod__Vlan__ResetDebounceDuration = 2000
+# Pod__Vlan__ResetDebounceMaxDuration = 5000
 
 ####################
 ## Logging

--- a/src/TopoMojo.Hypervisor/Common/DateTimeOffsetRange.cs
+++ b/src/TopoMojo.Hypervisor/Common/DateTimeOffsetRange.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TopoMojo.Hypervisor.Common
+{
+    public sealed class DateTimeOffsetRange
+    {
+        public DateTimeOffset Start { get; set; }
+        public DateTimeOffset End { get; set; }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Common/DebounceAddCollection.cs
+++ b/src/TopoMojo.Hypervisor/Common/DebounceAddCollection.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace TopoMojo.Hypervisor.Common
+{
+    public sealed class DebounceAddCollection<T>
+    {
+        private readonly object _collectionLock = new object();
+        private DateTimeOffsetRange _currentDebounce = null;
+        private readonly object _currentDebounceLock = new object();
+        private readonly SemaphoreSlim _semaphoreLock = new SemaphoreSlim(1);
+        private readonly double _debouncePeriod;
+        private readonly int? _maxTotalDebounce = null;
+        private readonly ConcurrentBag<T> _items = new ConcurrentBag<T>();
+        public event EventHandler<IEnumerable<T>> Modified;
+
+        public DebounceAddCollection(int debounceDurationMs)
+        {
+            _debouncePeriod = debounceDurationMs;
+        }
+
+        public DebounceAddCollection(int debounceDurationMs, int maxTotalDebounceDurationMs)
+        {
+            _debouncePeriod = debounceDurationMs;
+            _maxTotalDebounce = maxTotalDebounceDurationMs;
+        }
+
+        public int Length { get => _items.Count; }
+
+        public Task<IEnumerable<T>> Add(T item, CancellationToken cancellationToken)
+            => AddRange(new T[] { item }, cancellationToken);
+
+        public async Task<IEnumerable<T>> AddRange(IEnumerable<T> items, CancellationToken cancellationToken)
+        {
+            // add the item to the collection immediately (independent of debounce settings)
+            lock (_collectionLock)
+            {
+                foreach (var item in items.ToArray())
+                {
+                    _items.Add(item);
+                }
+            }
+
+            var nowish = DateTimeOffset.UtcNow;
+            lock (_currentDebounceLock)
+            {
+                if (_currentDebounce is null)
+                {
+                    // start a new debounce if there's not one currently in the hopper
+                    _currentDebounce = new DateTimeOffsetRange
+                    {
+                        Start = nowish,
+                        End = nowish.AddMilliseconds(_debouncePeriod)
+                    };
+                }
+                else
+                {
+                    // if there's a current debounce happening, refresh the period length (e.g. if the debounce period is 300ms and an item is added 250ms after the last one,
+                    // the debounce timer should reset to 300ms after the second item is added)
+                    _currentDebounce.End = nowish.AddMilliseconds(_debouncePeriod);
+                    // BUT if there's a maximum total debounce time, we have to ensure that we don't overflow it, so clamp the value to the maximum remaining if it would
+                    if (_maxTotalDebounce.HasValue)
+                    {
+                        var maxDebounceEnds = _currentDebounce.Start.AddMilliseconds(_maxTotalDebounce.Value);
+                        if (maxDebounceEnds < _currentDebounce.End)
+                        {
+                            _currentDebounce.End = maxDebounceEnds;
+                            Console.WriteLine($"Clamped to {_currentDebounce.End}");
+                        }
+                    }
+                }
+            }
+
+            // after waiting for the appropriate delay, return the contents of the collection
+            try
+            {
+                await _semaphoreLock.WaitAsync(cancellationToken);
+                if (_currentDebounce != null)
+                {
+                    var delayLength = 0;
+                    do
+                    {
+                        delayLength = (int)Math.Ceiling((_currentDebounce.End - DateTimeOffset.UtcNow).TotalMilliseconds);
+                        if (delayLength > 0)
+                            await Task.Delay(delayLength, cancellationToken);
+                    }
+                    while (delayLength > 0);
+                }
+
+                lock (_currentDebounceLock)
+                {
+                    _currentDebounce = null;
+                }
+
+                // get a new array that points to the contents of _items for thread safety
+                var itemsThreadSafe = this._items.ToArray();
+                this.Modified?.Invoke(this, itemsThreadSafe);
+                return itemsThreadSafe;
+            }
+            finally
+            {
+                _semaphoreLock.Release();
+            }
+        }
+
+        public void Clear()
+        {
+            foreach (var item in _items)
+            {
+                _items.TryTake(out _);
+            }
+        }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Common/DebouncePool.cs
+++ b/src/TopoMojo.Hypervisor/Common/DebouncePool.cs
@@ -16,6 +16,11 @@ namespace TopoMojo.Hypervisor.Common
         private readonly SemaphoreSlim _semaphoreLock = new SemaphoreSlim(1);
         private readonly ConcurrentBag<T> _items = new ConcurrentBag<T>();
 
+        public DebouncePool()
+        {
+            DebouncePeriod = 0;
+        }
+
         public DebouncePool(int debounceDurationMs)
         {
             DebouncePeriod = debounceDurationMs;

--- a/src/TopoMojo.Hypervisor/Common/DebouncePool.cs
+++ b/src/TopoMojo.Hypervisor/Common/DebouncePool.cs
@@ -80,7 +80,7 @@ namespace TopoMojo.Hypervisor.Common
 
                 if (_currentDebounce != null)
                 {
-                    var delayLength = 0;
+                    int delayLength;
                     do
                     {
                         delayLength = (int)Math.Ceiling((_currentDebounce.End - DateTimeOffset.UtcNow).TotalMilliseconds);
@@ -90,18 +90,20 @@ namespace TopoMojo.Hypervisor.Common
                     while (delayLength > 0);
                 }
 
+                var itemsThreadSafe = Array.Empty<T>();
+
                 lock (_currentDebounceLock)
                 {
                     _currentDebounce = null;
-                }
 
-                // get a new array that points to the contents of _items for thread safety
-                var itemsThreadSafe = this._items.ToArray();
+                    // get a new array that points to the contents of _items for thread safety
+                    itemsThreadSafe = this._items.ToArray();
 
-                // clear the collection (.Clear() isn't supported in .netstandard2.0)
-                foreach (var item in _items)
-                {
-                    _items.TryTake(out _);
+                    // clear the collection (.Clear() isn't supported in .netstandard2.0)
+                    foreach (var item in _items)
+                    {
+                        _items.TryTake(out _);
+                    }
                 }
 
                 return new DebouncePoolBatch<T>

--- a/src/TopoMojo.Hypervisor/Common/DebouncePool.cs
+++ b/src/TopoMojo.Hypervisor/Common/DebouncePool.cs
@@ -9,6 +9,7 @@ namespace TopoMojo.Hypervisor.Common
 {
     public sealed class DebouncePool<T>
     {
+        private string _id;
         private readonly object _collectionLock = new object();
         private DateTimeOffsetRange _currentDebounce = null;
         private readonly object _currentDebounceLock = new object();
@@ -54,6 +55,7 @@ namespace TopoMojo.Hypervisor.Common
                         Start = nowish,
                         End = nowish.AddMilliseconds(this.DebouncePeriod)
                     };
+                    _id = Guid.NewGuid().ToString();
                 }
                 else
                 {
@@ -67,7 +69,6 @@ namespace TopoMojo.Hypervisor.Common
                         if (maxDebounceEnds < _currentDebounce.End)
                         {
                             _currentDebounce.End = maxDebounceEnds;
-                            Console.WriteLine($"Clamped to {_currentDebounce.End}");
                         }
                     }
                 }
@@ -108,7 +109,7 @@ namespace TopoMojo.Hypervisor.Common
 
                 return new DebouncePoolBatch<T>
                 {
-                    Id = Guid.NewGuid().ToString(),
+                    Id = _id,
                     Items = itemsThreadSafe
                 };
             }

--- a/src/TopoMojo.Hypervisor/Common/DebouncePoolBatch.cs
+++ b/src/TopoMojo.Hypervisor/Common/DebouncePoolBatch.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace TopoMojo.Hypervisor
+{
+    public sealed class DebouncePoolBatch<T>
+    {
+        public string Id { get; set; }
+        public IEnumerable<T> Items { get; set; }
+    }
+}

--- a/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
+++ b/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
@@ -19,7 +19,6 @@ namespace TopoMojo.Hypervisor
         public string VmStore { get; set; } = "[topomojo] _run/";
         public string DiskStore { get; set; } = "[topomojo]";
         public string IsoStore { get; set; } = "[topomojo] iso/";
-        public string NodeIsoStore { get; set; } = "nfs";
         public string TicketUrlHandler { get; set; } = "querystring"; //"local-app", "external-domain", "host-map", "none"
         public Dictionary<string, string> TicketUrlHostMap { get; set; } = new Dictionary<string, string>();
         public VlanConfiguration Vlan { get; set; } = new VlanConfiguration();
@@ -51,8 +50,8 @@ namespace TopoMojo.Hypervisor
     {
         public string Range { get; set; } = "";
         public Vlan[] Reservations { get; set; } = new Vlan[] { };
-        public int ResetDebounceDuration { get; set; } = 300;
-        public int? ResetDebounceMaxDuration { get; set; } = null;
+        public int ResetDebounceDuration { get; set; } = 2000;
+        public int? ResetDebounceMaxDuration { get; set; } = 5000;
     }
 
     public class Vlan

--- a/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
+++ b/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
@@ -51,6 +51,8 @@ namespace TopoMojo.Hypervisor
     {
         public string Range { get; set; } = "";
         public Vlan[] Reservations { get; set; } = new Vlan[] { };
+        public int ResetDebounceDuration { get; set; } = 300;
+        public int? ResetDebounceMaxDuration { get; set; } = null;
     }
 
     public class Vlan

--- a/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
+++ b/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
@@ -19,8 +19,9 @@ namespace TopoMojo.Hypervisor
         public string VmStore { get; set; } = "[topomojo] _run/";
         public string DiskStore { get; set; } = "[topomojo]";
         public string IsoStore { get; set; } = "[topomojo] iso/";
-        public string TicketUrlHandler { get; set; }  = "querystring"; //"local-app", "external-domain", "host-map", "none"
-        public Dictionary<string,string> TicketUrlHostMap { get; set; } = new Dictionary<string, string>();
+        public string NodeIsoStore { get; set; } = "nfs";
+        public string TicketUrlHandler { get; set; } = "querystring"; //"local-app", "external-domain", "host-map", "none"
+        public Dictionary<string, string> TicketUrlHostMap { get; set; } = new Dictionary<string, string>();
         public VlanConfiguration Vlan { get; set; } = new VlanConfiguration();
         public int KeepAliveMinutes { get; set; } = 10;
         public string ExcludeNetworkMask { get; set; } = "topomojo";

--- a/src/TopoMojo.Hypervisor/Proxmox/Models/CreatePveVnet.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/Models/CreatePveVnet.cs
@@ -1,0 +1,9 @@
+namespace TopoMojo.Hypervisor.Proxmox.Models
+{
+    public sealed class CreatePveVnet
+    {
+        public string Alias { get; set; }
+        public string Zone { get; set; }
+    }
+}
+

--- a/src/TopoMojo.Hypervisor/Proxmox/Models/PveIso.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/Models/PveIso.cs
@@ -6,7 +6,7 @@ namespace TopoMojo.Hypervisor.Proxmox.Models
         public string Format { get; set; }
         public string Content { get; set; }
         public int Ctime { get; set; }
-        public int Size { get; set; }
+        public long Size { get; set; }
 
         public string Name
         {

--- a/src/TopoMojo.Hypervisor/Proxmox/Models/PveVnetOperation.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/Models/PveVnetOperation.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace TopoMojo.Hypervisor.Proxmox.Models
+{
+    internal sealed class PveVnetOperation : IEquatable<PveVnetOperation>
+    {
+        public PveVnetOperationType Type { get; private set; } = PveVnetOperationType.Create;
+        public string NetworkName { get; private set; } = string.Empty;
+
+        public PveVnetOperation(string networkName, PveVnetOperationType type)
+        {
+            NetworkName = networkName;
+            Type = type;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj.GetType() != typeof(PveVnetOperation))
+                return false;
+
+            var typedObj = obj as PveVnetOperation;
+
+            return Equals(typedObj);
+        }
+
+        public bool Equals(PveVnetOperation other)
+        {
+            return
+                other.NetworkName == this.NetworkName &&
+                other.Type == this.Type;
+        }
+
+        public override int GetHashCode()
+            => (NetworkName + Type.ToString()).GetHashCode();
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/Models/PveVnetOperationResult.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/Models/PveVnetOperationResult.cs
@@ -1,0 +1,14 @@
+namespace TopoMojo.Hypervisor.Proxmox.Models
+{
+    public sealed class PveVnetOperationResult
+    {
+        public string NetName { get; set; }
+        public PveVnet Vnet { get; set; }
+        public PveVnetOperationType Type { get; set; } = PveVnetOperationType.Create;
+
+        public override string ToString()
+        {
+            return $"{NetName} :: {Vnet.Zone}.{Vnet.Alias} :: {Type}";
+        }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/Models/PveVnetOperationType.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/Models/PveVnetOperationType.cs
@@ -1,0 +1,8 @@
+namespace TopoMojo.Hypervisor.Proxmox.Models
+{
+    public enum PveVnetOperationType
+    {
+        Create,
+        Delete
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -14,7 +14,6 @@ using System.Net;
 using System.Collections.Generic;
 using TopoMojo.Hypervisor.Proxmox.Models;
 using TopoMojo.Hypervisor.Extensions;
-using System.Threading;
 
 namespace TopoMojo.Hypervisor.Proxmox
 {

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -154,7 +154,7 @@ namespace TopoMojo.Hypervisor.Proxmox
             var task = await _pveClient.Nodes[parentTemplate.Host].Qemu[parentTemplate.Id].Clone.CloneVm(
                 pveId,
                 full: true,
-                name: ToPveName(template.Template),
+                name: _nameService.ToPveName(template.Template),
                 target: parentTemplate.Host);
             await _pveClient.WaitForTaskToFinishAsync(task);
 

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -114,7 +114,8 @@ namespace TopoMojo.Hypervisor.Proxmox
             Result task;
             Vm vm = null;
 
-            _logger.LogDebug("deploy: virtual networks...");
+            _logger.LogDebug($"deploy: virtual networks (id {template.Id})...");
+
             var vnets = await _vlanManager.Provision(template.Eth.Select(n => n.Net), CancellationToken.None);
             _logger.LogDebug($"deploy: {vnets.Count()} networks deployed.");
 

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
@@ -110,12 +110,9 @@ namespace TopoMojo.Hypervisor.Proxmox
 
         public async Task<VmOptions> GetVmNetOptions(string id)
         {
-            var hostVnets = await _pveClient.GetVnets();
+            var hostVnets = await _vlanManager.GetVnets();
 
-            return new VmOptions
-            {
-                Net = hostVnets.Select(n => n.Alias).ToArray()
-            };
+            return new VmOptions { Net = hostVnets.Select(n => n.Alias).ToArray() };
         }
 
         public string Version
@@ -323,18 +320,7 @@ namespace TopoMojo.Hypervisor.Proxmox
         public async Task DeleteAll(string target)
         {
             _logger.LogDebug("deleting all matching " + target);
-            var tasks = new List<Task>();
-            foreach (var vm in await Find(target))
-            {
-                tasks.Add(_pveClient.Delete(vm.Id));
-            }
-
-            if (tasks.Count > 0)
-            {
-                await Task.WhenAll(tasks.ToArray());
-            }
-
-            await _pveClient.CleanupNetworks(target);
+            await _pveClient.DeleteAll(target);
         }
 
         public async Task<Vm> ChangeState(VmOperation op)

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxNameService.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxNameService.cs
@@ -1,0 +1,21 @@
+namespace TopoMojo.Hypervisor.Proxmox
+{
+    public interface IProxmoxNameService
+    {
+        string ToPveName(string name);
+        string FromPveName(string pveName);
+    }
+
+    public class ProxmoxNameService : IProxmoxNameService
+    {
+        public string ToPveName(string name)
+        {
+            return name.Replace("#", "--");
+        }
+
+        public string FromPveName(string pveName)
+        {
+            return pveName.Replace("--", "#");
+        }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxNameService.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxNameService.cs
@@ -8,14 +8,13 @@ namespace TopoMojo.Hypervisor.Proxmox
 
     public class ProxmoxNameService : IProxmoxNameService
     {
+        public bool IsPveName(string name)
+            => name.Contains("--");
+
         public string ToPveName(string name)
-        {
-            return name.Replace("#", "--");
-        }
+            => name.Replace("#", "--");
 
         public string FromPveName(string pveName)
-        {
-            return pveName.Replace("--", "#");
-        }
+            => pveName.Replace("--", "#");
     }
 }

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVlanManager.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVlanManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -13,9 +12,12 @@ namespace TopoMojo.Hypervisor.Proxmox
 {
     public interface IProxmoxVlanManager
     {
+        Task<IEnumerable<PveVnet>> DeleteVnets(IEnumerable<string> vnetNames);
+        Task<IEnumerable<PveVnet>> DeleteVnetsByTerm(string term);
+        Task<IEnumerable<PveVnet>> GetVnets();
         Task<bool> HasNetwork(string networkName);
         Task<bool> HasNetworks(IEnumerable<string> networkNames);
-        Task<IEnumerable<PveVnet>> Provision(IEnumerable<string> vnetNames, CancellationToken cancellationToken);
+        Task<IEnumerable<PveVnet>> Provision(IEnumerable<string> vnetNames);
     }
 
     public class ProxmoxVlanManager : IProxmoxVlanManager
@@ -23,86 +25,124 @@ namespace TopoMojo.Hypervisor.Proxmox
         private readonly static Lazy<SemaphoreSlim> _deploySemaphore = new Lazy<SemaphoreSlim>(() => new SemaphoreSlim(1));
         // defaults to a debounce period of 300ms, but can be changed using the `Pod__Vnet__ResetDebounceDuration`. A maximum
         // debounce can be set using `Pod__VNet__ResetDebounceMaxDuration`.
-        private readonly static Lazy<DebouncePool<string>> _vnetDeployNames = new Lazy<DebouncePool<string>>(() => new DebouncePool<string>(300));
+        private readonly static Lazy<DebouncePool<PveVnetOperation>> _vnetOpsPool = new Lazy<DebouncePool<PveVnetOperation>>(() => new DebouncePool<PveVnetOperation>(300));
+        private readonly static Lazy<DebouncePool<string>> _createVnetNamesPool = new Lazy<DebouncePool<string>>(() => new DebouncePool<string>(300));
         private readonly static IMemoryCache _debounceBatchCreationCache = new MemoryCache(new MemoryCacheOptions { });
+        private readonly static IMemoryCache _recentVnetOpsCache = new MemoryCache(new MemoryCacheOptions { });
 
+        private readonly int _cacheDurationMs = 600;
         private readonly HypervisorServiceConfiguration _hypervisorOptions;
         private readonly ILogger<ProxmoxVlanManager> _logger;
         private readonly IProxmoxNameService _nameService;
-        private readonly ProxmoxClient _proxmox;
+        private readonly IProxmoxVnetsClient _vnetsApi;
 
         public ProxmoxVlanManager
         (
             HypervisorServiceConfiguration hypervisorOptions,
-            ILogger<ProxmoxClient> clientLogger,
             ILogger<ProxmoxVlanManager> logger,
             IProxmoxNameService nameService,
-            Random random
+            IProxmoxVnetsClient vnetsApi
         )
         {
             _hypervisorOptions = hypervisorOptions;
             _logger = logger;
             _nameService = nameService;
-
-            _proxmox = new ProxmoxClient(
-                hypervisorOptions,
-                new ConcurrentDictionary<string, Vm>(),
-                clientLogger,
-                nameService,
-                this,
-                random);
+            _vnetsApi = vnetsApi;
 
             // update the debounce pool to use settings from config
-            _vnetDeployNames.Value.DebouncePeriod = _hypervisorOptions.Vlan.ResetDebounceDuration;
-            _vnetDeployNames.Value.MaxTotalDebounce = _hypervisorOptions.Vlan.ResetDebounceMaxDuration;
+            _vnetOpsPool.Value.DebouncePeriod = _hypervisorOptions.Vlan.ResetDebounceDuration;
+            _vnetOpsPool.Value.MaxTotalDebounce = _hypervisorOptions.Vlan.ResetDebounceMaxDuration;
+            _createVnetNamesPool.Value.DebouncePeriod = _hypervisorOptions.Vlan.ResetDebounceDuration;
+            _createVnetNamesPool.Value.MaxTotalDebounce = _hypervisorOptions.Vlan.ResetDebounceMaxDuration;
+
+            // cache this - we need this to remain at least long as the maximum possible debounce (if it's defined). If it is, 
+            // add a couple seconds for safety. if not, just double the min debounce up to a maximum of two seconds
+            _cacheDurationMs = _hypervisorOptions.Vlan.ResetDebounceMaxDuration != null ? _hypervisorOptions.Vlan.ResetDebounceMaxDuration.Value + 2000 : Math.Min(_hypervisorOptions.Vlan.ResetDebounceDuration * 2, 2000);
         }
 
-        public async Task<IEnumerable<PveVnet>> Provision(IEnumerable<string> vnetNames, CancellationToken cancellationToken)
+        private async Task<IEnumerable<PveVnetOperationResult>> DebounceVnetOperations(IEnumerable<PveVnetOperation> requestedOperations)
         {
-            _logger.LogDebug($"Deploying vnets: {string.Join(",", vnetNames)}");
-            var debouncedVnetNames = await _vnetDeployNames.Value.AddRange(vnetNames, CancellationToken.None);
-            debouncedVnetNames.Items = debouncedVnetNames.Items.Distinct();
+            var debouncedOperations = await _vnetOpsPool.Value.AddRange(requestedOperations, CancellationToken.None);
+
+            // PveVnetOperation implements object comparison, so we can use .Distinct to ensure we don't ever try a duplicate op (at least not in the same debounce)
+            debouncedOperations.Items = debouncedOperations.Items.Distinct();
 
             try
             {
-                await _deploySemaphore.Value.WaitAsync(cancellationToken);
+                await _deploySemaphore.Value.WaitAsync(CancellationToken.None);
 
                 // check the cache to see if this debounce batch has already been created.
                 // if so, just bail out and return what we already have
-                _logger.LogDebug($"Looking up id {debouncedVnetNames.Id}");
-                if (_debounceBatchCreationCache.TryGetValue<IEnumerable<PveVnet>>(debouncedVnetNames.Id, out var cachedDeployedVNets))
+                _logger.LogDebug($"Looking up id {debouncedOperations.Id}");
+                if (_debounceBatchCreationCache.TryGetValue<IEnumerable<PveVnetOperationResult>>(debouncedOperations.Id, out var cachedOperations))
                 {
-                    var createdVnetNames = cachedDeployedVNets.Select(v => v.Alias).ToArray();
-
-                    if (debouncedVnetNames.Items.All(newName => createdVnetNames.Contains(newName)))
-                        return cachedDeployedVNets;
+                    return cachedOperations.Where(o => requestedOperations.Any(req => req.Equals(o)));
                 }
-                _logger.LogDebug($"Cache miss {debouncedVnetNames.Id}");
+                _logger.LogDebug($"Cache miss {debouncedOperations.Id}");
 
-                // the proxmox client does all the heavy lifting of normalizing names, reloading the vnet host, etc.
-                var deployedVnets = await _proxmox.CreateVnets(debouncedVnetNames.Items.Select(n => new CreatePveVnet { Alias = n, Zone = _hypervisorOptions.SDNZone }));
+                var results = new List<PveVnetOperationResult>();
+                var vnetsToCreate = debouncedOperations.Items.Where(op => op.Type == PveVnetOperationType.Create).ToArray();
+                var vnetsToDelete = debouncedOperations.Items.Where(op => op.Type == PveVnetOperationType.Delete).ToArray();
 
-                if (deployedVnets.Any())
+                if (vnetsToCreate.Any())
                 {
-                    // cache the id of the debounce batch we just handled (so later callers won't try to recreate the vnets)
-                    _debounceBatchCreationCache
-                        .GetOrCreate
+                    var vnetNamesToCreate = vnetsToCreate.Select(v => _nameService.ToPveName(v.NetworkName));
+                    var deployedVnets = await _vnetsApi.CreateVnets(vnetsToCreate.Select(n => new CreatePveVnet
+                    {
+                        Alias = _nameService.ToPveName(n.NetworkName),
+                        Zone = _hypervisorOptions.SDNZone
+                    }));
+
+                    results.AddRange(deployedVnets.Select(v => new PveVnetOperationResult
+                    {
+                        NetName = _nameService.FromPveName(v.Alias),
+                        Vnet = v,
+                        Type = PveVnetOperationType.Create
+                    }));
+                }
+
+                if (vnetsToDelete.Any())
+                {
+                    var vnetNamesToDelete = vnetsToDelete.Select(n => _nameService.ToPveName(n.NetworkName));
+                    var deletedVnets = await _vnetsApi.DeleteVnets(vnetNamesToDelete);
+
+                    foreach (var deletedVnet in deletedVnets)
+                    {
+                        results.Add
                         (
-                            debouncedVnetNames.Id,
+                            new PveVnetOperationResult
+                            {
+                                NetName = _nameService.FromPveName(deletedVnet.Alias),
+                                Vnet = deletedVnet,
+                                Type = PveVnetOperationType.Delete
+                            });
+                    }
+                }
+
+                _logger.LogDebug($"Batch {debouncedOperations.Id} results: {string.Join(",", results)}");
+
+                if (results.Any())
+                {
+                    // because we're allowing creates/deletes in the same debounce pool and trying to minimize reload calls,
+                    // we manually reload proxmox's vnets at the end of the batch
+                    await _vnetsApi.ReloadVnets();
+
+                    // cache the id of the debounce batch we just handled (so later callers won't try to recreate/redelete the vnets)
+                    _recentVnetOpsCache
+                        .GetOrCreate<IEnumerable<PveVnetOperationResult>>
+                        (
+                            debouncedOperations.Id,
                             entry =>
                             {
-                                // cache this - we need this to remain at least long as the maximum possible debounce (if it's defined). If it is, 
-                                // add a couple seconds for safety. if not, just double the min debounce.
-                                var cacheDuration = _hypervisorOptions.Vlan.ResetDebounceMaxDuration != null ? _hypervisorOptions.Vlan.ResetDebounceMaxDuration.Value + 2000 : _hypervisorOptions.Vlan.ResetDebounceDuration;
-                                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(cacheDuration);
-                                return deployedVnets;
+                                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(_cacheDurationMs);
+                                return results;
                             }
                         );
 
-                    _logger.LogDebug($"Cached id {debouncedVnetNames.Id}");
+                    _logger.LogDebug($"Cached id {debouncedOperations.Id}");
                 }
 
-                return deployedVnets;
+                return results;
             }
             finally
             {
@@ -110,16 +150,78 @@ namespace TopoMojo.Hypervisor.Proxmox
             }
         }
 
+        public async Task<IEnumerable<PveVnet>> DeleteVnets(IEnumerable<string> vnetNames)
+        {
+            _logger.LogDebug($"Deleting vnets: {string.Join(",", vnetNames)}");
+            vnetNames = vnetNames
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Distinct();
+
+            if (!vnetNames.Any())
+            {
+                _logger.LogDebug($"No vnet names passed. Cancelling vnet delete.");
+                return Array.Empty<PveVnet>();
+            }
+
+            // create the nets
+            var results = await DebounceVnetOperations(vnetNames.Select(name => new PveVnetOperation(name, PveVnetOperationType.Create)));
+
+            // the results contain all network operations performed this debounce, but we only want to send back the ones related to
+            // the requested names
+            var pveVnetNames = vnetNames.Select(name => _nameService.ToPveName(name)).ToArray();
+            return results
+                .Where(r => pveVnetNames.Contains(r.Vnet.Alias))
+                .Select(r => r.Vnet);
+        }
+
+        public async Task<IEnumerable<PveVnet>> DeleteVnetsByTerm(string term)
+        {
+            var vnets = await _vnetsApi.GetVnets();
+            var matchingVnetDeleteOps = vnets
+                .Where(v => v.Alias.Contains(term))
+                .Select(v => new PveVnetOperation
+                (
+                    v.Alias,
+                    PveVnetOperationType.Delete
+                ));
+
+            var results = await this.DebounceVnetOperations(matchingVnetDeleteOps);
+            return results
+                .Where(r => r.NetName.Contains(term))
+                .Select(r => r.Vnet);
+        }
+
+        public Task<IEnumerable<PveVnet>> GetVnets()
+            => _vnetsApi.GetVnets();
+
+        public async Task<IEnumerable<PveVnet>> Provision(IEnumerable<string> vnetNames)
+        {
+            _logger.LogDebug($"Deploying vnets: {string.Join(",", vnetNames)}");
+            vnetNames = vnetNames
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Distinct();
+
+            if (!vnetNames.Any())
+            {
+                _logger.LogDebug($"No vnet names passed. Cancelling vnet deploy.");
+                return Array.Empty<PveVnet>();
+            }
+
+            // create the nets
+            var results = await DebounceVnetOperations(vnetNames.Select(name => new PveVnetOperation(name, PveVnetOperationType.Create)));
+
+            // the results contain all network operations performed this debounce, but we only want to send back the ones related to
+            // the requested names
+            var pveVnetNames = vnetNames.Select(name => _nameService.ToPveName(name)).ToArray();
+            return results
+                .Where(r => pveVnetNames.Contains(r.Vnet.Alias))
+                .Select(r => r.Vnet);
+        }
+
         public Task<bool> HasNetwork(string networkName)
             => HasNetworks(new string[] { networkName });
 
-        public async Task<bool> HasNetworks(IEnumerable<string> networkNames)
-        {
-            var hostNets = await _proxmox.GetVnets();
-
-            return networkNames
-                .Select(n => _nameService.ToPveName(n))
-                .All(n => hostNets.Any(vnet => vnet.Alias == n));
-        }
+        public Task<bool> HasNetworks(IEnumerable<string> networkNames)
+            => _vnetsApi.GetVnetsExist(networkNames.Select(n => _nameService.ToPveName(n)));
     }
 }

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVlanManager.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVlanManager.cs
@@ -217,7 +217,12 @@ namespace TopoMojo.Hypervisor.Proxmox
         public Task<bool> HasNetwork(string networkName)
             => HasNetworks(new string[] { networkName });
 
-        public Task<bool> HasNetworks(IEnumerable<string> networkNames)
-            => _vnetsApi.GetVnetsExist(networkNames.Select(n => _nameService.ToPveName(n)));
+        public async Task<bool> HasNetworks(IEnumerable<string> networkNames)
+        {
+            var nets = await _vnetsApi.GetVnets();
+            var pveNames = networkNames.Select(n => _nameService.ToPveName(n));
+
+            return pveNames.All(name => nets.Any(net => net.Alias == name));
+        }
     }
 }

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetService.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetService.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Corsinvest.ProxmoxVE.Api;
+using TopoMojo.Hypervisor.Common;
+using TopoMojo.Hypervisor.Proxmox.Models;
+
+namespace TopoMojo.Hypervisor.Proxmox
+{
+    public interface IProxmoxVnetService
+    {
+        Task<IEnumerable<PveVnet>> Deploy(IEnumerable<string> vnetNames, CancellationToken cancellationToken);
+    }
+
+    public class ProxmoxVnetService : IProxmoxVnetService
+    {
+        private readonly static Lazy<SemaphoreSlim> DEPLOY_SEMAPHORE = new Lazy<SemaphoreSlim>(() => new SemaphoreSlim(1));
+        private readonly static Lazy<DebounceAddCollection<string>> VNET_DEPLOY_NAMES = new Lazy<DebounceAddCollection<string>>(() => new DebounceAddCollection<string>(300));
+
+        private readonly HypervisorServiceConfiguration _hypervisorOptions;
+        private readonly IProxmoxNameService _nameService;
+        private readonly PveClient _pveClient;
+        private readonly Random _random;
+
+        public ProxmoxVnetService
+        (
+            HypervisorServiceConfiguration hypervisorOptions,
+            IProxmoxNameService nameService,
+            Random random
+        )
+        {
+            _hypervisorOptions = hypervisorOptions;
+            _nameService = nameService;
+            _pveClient = new PveClient(hypervisorOptions.Host, 443) { ApiToken = hypervisorOptions.Password };
+            _random = random;
+        }
+
+        public async Task<IEnumerable<PveVnet>> Deploy(IEnumerable<string> vnetNames, CancellationToken cancellationToken)
+        {
+            var debouncedVnetNames = await VNET_DEPLOY_NAMES.Value.AddRange(vnetNames, CancellationToken.None);
+
+            try
+            {
+                await DEPLOY_SEMAPHORE.Value.WaitAsync(cancellationToken);
+
+                var task = _pveClient.Cluster.Sdn.Vnets.Index().Result;
+                var hostNets = task.ToModel<PveVnet[]>();
+                var newNets = debouncedVnetNames.Where(vnetName => !hostNets.Any(n => n.Alias == _nameService.ToPveName(vnetName))).Distinct();
+                var deployedVNets = new List<PveVnet>();
+
+                foreach (var vnetName in newNets)
+                {
+                    var newVnetTag = default(int?);
+
+                    do
+                    {
+                        newVnetTag = _random.Next(100, 100000);
+                    }
+                    while (hostNets.Any(n => n.Tag == newVnetTag));
+
+                    var vnetId = this.GetRandomVnetId();
+                    var pveName = _nameService.ToPveName(vnetName);
+
+                    var createTask = _pveClient.Cluster.Sdn.Vnets.Create
+                    (
+                        vnet: vnetId,
+                        tag: newVnetTag,
+                        zone: _hypervisorOptions.SDNZone,
+                        alias: pveName
+                    ).Result;
+
+                    if (createTask.IsSuccessStatusCode)
+                    {
+                        deployedVNets.Add(new PveVnet
+                        {
+                            Alias = pveName,
+                            Tag = newVnetTag.GetValueOrDefault(),
+                            Type = string.Empty,
+                            Vnet = vnetId,
+                            Zone = _hypervisorOptions.SDNZone
+                        });
+                    }
+                }
+
+                if (deployedVNets.Any())
+                {
+                    var reloadTask = _pveClient.Cluster.Sdn.Reload().Result;
+                    await _pveClient.WaitForTaskToFinishAsync(reloadTask);
+                }
+
+                return deployedVNets;
+            }
+            finally
+            {
+                VNET_DEPLOY_NAMES.Value.Clear();
+                DEPLOY_SEMAPHORE.Value.Release();
+            }
+        }
+
+        private string GetRandomVnetId()
+        {
+            var builder = new StringBuilder();
+            var _chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
+
+            for (int i = 0; i <= 7; i++)
+            {
+                builder.Append(_chars[_random.Next(_chars.Length)]);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Corsinvest.ProxmoxVE.Api;
+using Microsoft.Extensions.Logging;
+using TopoMojo.Hypervisor.Proxmox.Models;
+
+namespace TopoMojo.Hypervisor.Proxmox
+{
+    public interface IProxmoxVnetsClient
+    {
+        Task<IEnumerable<PveVnet>> CreateVnets(IEnumerable<CreatePveVnet> createVnets);
+        Task<IEnumerable<PveVnet>> DeleteVnets(IEnumerable<string> names);
+        Task<IEnumerable<PveVnet>> DeleteVnetsByTerm(string term);
+        Task<IEnumerable<PveVnet>> GetVnets();
+        Task<bool> GetVnetsExist(IEnumerable<string> networkAliases);
+        Task ReloadVnets();
+    }
+
+    public class ProxmoxVnetsClient : IProxmoxVnetsClient
+    {
+        private readonly ILogger<ProxmoxVnetsClient> _logger;
+        private readonly PveClient _pveClient;
+        private readonly Random _random;
+
+        public ProxmoxVnetsClient
+        (
+            HypervisorServiceConfiguration hypervisorOptions,
+            ILogger<ProxmoxVnetsClient> logger,
+            Random random
+        )
+        {
+            _logger = logger;
+            _pveClient = new PveClient(hypervisorOptions.Host, 443)
+            {
+                ApiToken = hypervisorOptions.Password
+            };
+            _random = random;
+        }
+
+        public async Task<IEnumerable<PveVnet>> CreateVnets(IEnumerable<CreatePveVnet> createVnets)
+        {
+            var existingNets = await this.GetVnets();
+            var deployedNets = new List<PveVnet>();
+
+            foreach (var createVnet in createVnets)
+            {
+                if (existingNets.Any(n => n.Alias == createVnet.Alias))
+                {
+                    _logger.LogDebug($"Skipped creating vnet {createVnet} - it already exists.");
+                    continue;
+                }
+
+                var newVnetTag = default(int?);
+
+                do
+                {
+                    newVnetTag = _random.Next(100, 100000);
+                }
+                while (existingNets.Any(n => n.Tag == newVnetTag));
+
+                var vnetId = this.GetRandomVnetId();
+
+                // check for existence of alias = vnetname--gamespaceid
+                var createTask = _pveClient.Cluster.Sdn.Vnets.Create
+                (
+                    vnet: vnetId,
+                    tag: newVnetTag,
+                    zone: createVnet.Zone,
+                    alias: createVnet.Alias
+                ).Result;
+
+                if (createTask.IsSuccessStatusCode)
+                {
+
+                    deployedNets.Add
+                    (
+                        new PveVnet
+                        {
+                            Alias = createVnet.Alias,
+                            Tag = newVnetTag.GetValueOrDefault(),
+                            Type = string.Empty,
+                            Vnet = vnetId,
+                            Zone = createVnet.Zone
+                        }
+                    );
+                }
+            }
+
+            if (deployedNets.Any())
+            {
+                await this.ReloadVnets();
+            }
+
+            return deployedNets;
+        }
+
+        public async Task<IEnumerable<PveVnet>> DeleteVnets(IEnumerable<string> aliases)
+        {
+            var vnets = await this.GetVnets();
+            var deletedPveNets = new List<PveVnet>();
+
+            foreach (var alias in aliases)
+            {
+                var vnet = vnets.SingleOrDefault(v => v.Alias == alias);
+
+                if (vnet != null)
+                {
+                    var deleteTask = await _pveClient.Cluster.Sdn.Vnets[vnet.Vnet].Delete();
+                    await this.WaitForProxmoxTask(deleteTask);
+
+                    if (deleteTask.IsSuccessStatusCode)
+                    {
+                        deletedPveNets.Add(vnet);
+                    }
+                }
+                else
+                {
+                    _logger.LogDebug($"Vnet delete requested for {alias}, but the network doesn't exist.");
+                }
+            }
+
+            return deletedPveNets;
+        }
+
+        public async Task<IEnumerable<PveVnet>> DeleteVnetsByTerm(string term)
+        {
+            var vnets = await this.GetVnets();
+            var deletedPveNets = new List<PveVnet>();
+
+            foreach (var vnet in vnets.Where(x => x.Alias.Contains(term)))
+            {
+                var deleteTask = await _pveClient.Cluster.Sdn.Vnets[vnet.Vnet].Delete();
+                await this.WaitForProxmoxTask(deleteTask);
+
+                if (deleteTask.IsSuccessStatusCode)
+                {
+                    deletedPveNets.Add(vnet);
+                }
+            }
+
+            return deletedPveNets;
+        }
+
+        public async Task<IEnumerable<PveVnet>> GetVnets()
+        {
+            var task = _pveClient.Cluster.Sdn.Vnets.Index().Result;
+            await WaitForProxmoxTask(task);
+
+            if (!task.IsSuccessStatusCode)
+                throw new Exception($"Failed to load virtual networks from Proxmox. Status code: {task.StatusCode}");
+
+            return task.ToModel<PveVnet[]>();
+        }
+
+        public async Task<bool> GetVnetsExist(IEnumerable<string> networkAliases)
+        {
+            var hostNets = await this.GetVnets();
+
+            return networkAliases.All(n => hostNets.Any(vnet => vnet.Alias == n));
+        }
+
+        public async Task ReloadVnets()
+        {
+            var reloadTask = _pveClient.Cluster.Sdn.Reload().Result;
+            await _pveClient.WaitForTaskToFinishAsync(reloadTask);
+        }
+
+        private string GetRandomVnetId()
+        {
+            var builder = new StringBuilder();
+            var _chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
+
+            for (int i = 0; i <= 7; i++)
+            {
+                builder.Append(_chars[_random.Next(_chars.Length)]);
+            }
+
+            return builder.ToString();
+        }
+
+        private async Task WaitForProxmoxTask(Result proxmoxTask)
+        {
+            try
+            {
+                await _pveClient.WaitForTaskToFinishAsync(proxmoxTask);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error waiting for task to finish");
+            }
+        }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
@@ -88,11 +88,6 @@ namespace TopoMojo.Hypervisor.Proxmox
                 }
             }
 
-            if (deployedNets.Any())
-            {
-                await this.ReloadVnets();
-            }
-
             return deployedNets;
         }
 

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
@@ -15,7 +15,6 @@ namespace TopoMojo.Hypervisor.Proxmox
         Task<IEnumerable<PveVnet>> DeleteVnets(IEnumerable<string> names);
         Task<IEnumerable<PveVnet>> DeleteVnetsByTerm(string term);
         Task<IEnumerable<PveVnet>> GetVnets();
-        Task<bool> GetVnetsExist(IEnumerable<string> networkAliases);
         Task ReloadVnets();
     }
 
@@ -153,13 +152,6 @@ namespace TopoMojo.Hypervisor.Proxmox
                 throw new Exception($"Failed to load virtual networks from Proxmox. Status code: {task.StatusCode}");
 
             return task.ToModel<PveVnet[]>();
-        }
-
-        public async Task<bool> GetVnetsExist(IEnumerable<string> networkAliases)
-        {
-            var hostNets = await this.GetVnets();
-
-            return networkAliases.All(n => hostNets.Any(vnet => vnet.Alias == n));
         }
 
         public async Task ReloadVnets()

--- a/src/TopoMojo.Hypervisor/Proxmox/VlanManager.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/VlanManager.cs
@@ -136,6 +136,5 @@ namespace TopoMojo.Hypervisor.Proxmox
             nets.Sort();
             return nets.ToArray();
         }
-
     }
 }

--- a/src/TopoMojo.Hypervisor/TopoMojo.Hypervisor.csproj
+++ b/src/TopoMojo.Hypervisor/TopoMojo.Hypervisor.csproj
@@ -8,10 +8,11 @@
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VimClient" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0"/>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0"/>
-    <PackageReference Include="Corsinvest.ProxmoxVE.Api" Version="8.2.1"/>
-    <PackageReference Include="Corsinvest.ProxmoxVE.Api.Extension" Version="8.2.1"/>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="VimClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0" />
+    <PackageReference Include="Corsinvest.ProxmoxVE.Api" Version="8.2.1" />
+    <PackageReference Include="Corsinvest.ProxmoxVE.Api.Extension" Version="8.2.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds infra to manage virtual networks for the Proxmox hypervisor.

Contributes two primary services and a data structure.

# Services

- **ProxmoxVlanManager:** encapsulates all the logic/"business rules" of the Topo app's interaction with Proxmox, like a unified debounce for creates/deletes, translation of Topo names to Proxmox-compatible names, finding virtual networks associated with a gamespace ID, and so on
- **ProxmoxVnetsClient:** encapsulates all API calls to Proxmox related to virtual networks. If the question is "how are we calling the Proxmox API to do x?", the answer is in this service

# Data structure (sort of)

- `DebouncePool<T>` - `ProxmoxVlanManager` uses one of these to ensure we're not pounding the Proxmox API. Configurable by new settings `Pod__Vlan__ResetDebounceDuration` and `Pod__Vlan__ResetDebounceMaxDuration`, it debounces all network create/deletes and asks Proxmox to reload its virtual networks after the completion of any batch.