### PR TITLE
MVP of network hopping

### DIFF
--- a/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
+++ b/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
@@ -139,11 +139,8 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 if (config.IsProxmox)
                 {
-                    services.AddSingleton<IHypervisorService, TopoMojo.Hypervisor.Proxmox.ProxmoxHypervisorService>();
-                    services.AddSingleton<IProxmoxNameService, ProxmoxNameService>();
-                    services.AddSingleton<IProxmoxVlanManager, ProxmoxVlanManager>();
-                    services.AddSingleton<IProxmoxVnetsClient, ProxmoxVnetsClient>();
-                    services.AddSingleton<Random>(_ => Random.Shared);
+                    // give proxmox Random.Shared since it's not directly available in netstandard2.0
+                    services.AddProxmoxHypervisor(Random.Shared);
                 }
                 else
                 {

--- a/src/TopoMojo.Hypervisor/Proxmox/Models/PveNic.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/Models/PveNic.cs
@@ -1,0 +1,15 @@
+namespace TopoMojo.Hypervisor.Proxmox
+{
+    public sealed class PveNic
+    {
+        public int Index { get; set; }
+        public string MacAddress { get; set; }
+
+        /// <summary>
+        /// Proxmox supports several "models" for network devices (e.g. virtio, Intel E1000, VMWare vmxnet3, etc.)
+        /// Proxmox stores the model along with the current network bridge the device is using in the format
+        /// {MODEL=MAC_ADDRESS,BRIDGE=PROXMOX_BRIDGE_ID} on the Extension properties of the VM.
+        /// </summary>
+        public string PveModel { get; set; }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/Models/PveVmConfig.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/Models/PveVmConfig.cs
@@ -1,0 +1,19 @@
+
+using System;
+using System.Collections.Generic;
+
+namespace TopoMojo.Hypervisor.Proxmox
+{
+    public sealed class PveVmConfig
+    {
+        public string Boot { get; set; }
+        public int Cores { get; set; }
+        public string Cpu { get; set; }
+        public string Digest { get; set; }
+        public IEnumerable<PveNic> Nics { get; set; } = Array.Empty<PveNic>();
+        public string OsType { get; set; }
+        public long MemoryInBytes { get; set; }
+        public string Smbios1 { get; set; }
+        public int Sockets { get; set; }
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxExtensions.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
-using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace TopoMojo.Hypervisor.Proxmox
 {
@@ -35,6 +35,26 @@ namespace TopoMojo.Hypervisor.Proxmox
             {
                 throw new InvalidOperationException("Unsupported NodeStorageContent type");
             }
+        }
+
+        /// <summary>
+        /// Adds support for the Proxmox hypervisor to Topomojo.
+        /// </summary>
+        /// <param name="services">The app's service collection.</param>
+        /// <param name="random">
+        ///     An instance of Random which will be used across the hypervisor's implementation. Where available,
+        ///     The thread-safe Random.Shared instance is recommended. If no instance is supplied, a default
+        ///     will be created.
+        /// </param>
+        /// <returns></returns>
+        public static IServiceCollection AddProxmoxHypervisor(this IServiceCollection services, Random random = null)
+        {
+            return services
+                .AddSingleton<IHypervisorService, ProxmoxHypervisorService>()
+                .AddSingleton<IProxmoxNameService, ProxmoxNameService>()
+                .AddSingleton<IProxmoxVlanManager, ProxmoxVlanManager>()
+                .AddSingleton<IProxmoxVnetsClient, ProxmoxVnetsClient>()
+                .AddSingleton(_ => random ?? new Random());
         }
     }
 }

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVlanManager.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVlanManager.cs
@@ -17,6 +17,7 @@ namespace TopoMojo.Hypervisor.Proxmox
         Task<IEnumerable<PveVnet>> GetVnets();
         bool IsReserved(string networkName);
         Task<IEnumerable<PveVnet>> Provision(IEnumerable<string> vnetNames);
+        string ResolvePveNetName(string topoName);
     }
 
     public class ProxmoxVlanManager : IProxmoxVlanManager
@@ -135,6 +136,9 @@ namespace TopoMojo.Hypervisor.Proxmox
                 .Where(r => pveVnetNames.Contains(r.Vnet.Alias))
                 .Select(r => r.Vnet);
         }
+
+        public string ResolvePveNetName(string topoName)
+            => IsReserved(topoName) ? topoName : _nameService.ToPveName(topoName);
 
         private void Reserve(IEnumerable<Vlan> vlans)
         {

--- a/src/TopoMojo.Hypervisor/Proxmox/PveVmUpdateConfig.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/PveVmUpdateConfig.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace TopoMojo.Hypervisor.Proxmox
+{
+    public sealed class PveVmUpdateConfig
+    {
+        public IDictionary<int, string> NetAssignments { get; private set; } = new Dictionary<int, string>();
+    }
+}


### PR DESCRIPTION
- Adds an implementation of `IHypervisorService`'s `ChangeConfiguration` (only supports changing NIC/bridge assignments as of now)
- Also added the ability to pull basic config info about a live VM from Proxmox
- Added an extension method to house all Proxmox service registrations