### PR TITLE
Feature/proxmox guest settings

### DIFF
--- a/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
+++ b/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
@@ -14,6 +14,7 @@ namespace TopoMojo.Hypervisor
         public string Host { get; set; }
         public string User { get; set; }
         public string Password { get; set; }
+        public string AccessToken { get; set; }
         public string PoolPath { get; set; }
         public string Uplink { get; set; } = "dvs-topomojo";
         public string VmStore { get; set; } = "[topomojo] _run/";

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -231,11 +231,11 @@ namespace TopoMojo.Hypervisor.Proxmox
             if (task.IsSuccessStatusCode)
             {
                 // Proxmox requires using the root user account directly (not an access token)
-                // for settings the args field to add arbitrary arguments to the QEMU command line. This is currently the only
+                // for setting the args field to add arbitrary arguments to the QEMU command line. This is currently the only
                 // way to set the fw_cfg property that we need for Guest Settings.
                 // A Patch is available to add direct fw_cfg support but has not been merged into a release.
                 // https://bugzilla.proxmox.com/show_bug.cgi?id=4068
-                // If no root password is provided, skip setting args
+                // If no root password is provided, skip setting args.
                 var client = _pveClient;
                 var setGuestSettings = false;
 

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
@@ -34,7 +34,7 @@ namespace TopoMojo.Hypervisor.Proxmox
             _logger = logger;
             _pveClient = new PveClient(hypervisorOptions.Host, 443)
             {
-                ApiToken = hypervisorOptions.Password
+                ApiToken = hypervisorOptions.AccessToken
             };
             _random = random;
         }


### PR DESCRIPTION
Adds support for Guest Settings in Proxmox guests.

Uses QEMU Firmware Configuration (fw_cfg) to set key value pairs that can be read from inside guest virtual machines. On a Linux host, these can be read through by running `sudo cat /sys/firmware/qemu_fw_cfg/by_name/opt/guestinfo.key/raw`, where key is the name of the key of your guest setting. 

This does not seem to support Windows yet, though there is some basic support for fw_cfg in this kvm guest driver: https://github.com/virtio-win/kvm-guest-drivers-windows/tree/master

Proxmox requires logging in directly with the root password to set QEMU guest args, which are needed for fw_cfg (at least until the patch at https://bugzilla.proxmox.com/show_bug.cgi?id=4068 is merged), so this adds a separate AccessToken setting for the normal access token, and will optionally log in as root with the Password setting for setting args on a vm, if provided. If no root password is set, Guest Settings will be skipped. 