### PR TITLE
fix for parent template attached to a missing workspace

### DIFF
--- a/src/TopoMojo.Api/Features/Admin/TransferService.cs
+++ b/src/TopoMojo.Api/Features/Admin/TransferService.cs
@@ -373,6 +373,11 @@ namespace TopoMojo.Api.Services
                                 tmp.Parent = null;
                                 tmp.Workspace = null;
                                 newTemplates.Add(tmp);
+                                // handle the case where a parent template was attached to a workspace that is not in the upload
+                                if (tmp.WorkspaceId != null && !existingWorkspaceIds.Contains(tmp.WorkspaceId))
+                                {
+                                    tmp.WorkspaceId = null;
+                                }
                                 existingTemplateIds.Add(tmp.Id);
                             }
                         }


### PR DESCRIPTION
handle the case where a parent template was attached to a workspace that is not included in the upload