### PR TITLE
fix app crash when encountering an exception deleting a workspace

### DIFF
--- a/src/TopoMojo.Api/Features/Workspace/IWorkspaceStore.cs
+++ b/src/TopoMojo.Api/Features/Workspace/IWorkspaceStore.cs
@@ -19,6 +19,6 @@ namespace TopoMojo.Api.Data.Abstractions
         Task<Workspace> Clone(string id, string tenantId);
         IQueryable<Template> ListScopedTemplates();
         Task<int> CheckGamespaceCount(string id);
-        Task DeleteWithTemplates(string id, Action<IEnumerable<Template>> templateAction);
+        Task DeleteWithTemplates(string id, Func<IEnumerable<Data.Template>, Task> templateAction);
     }
 }

--- a/src/TopoMojo.Api/Features/Workspace/WorkspaceStore.cs
+++ b/src/TopoMojo.Api/Features/Workspace/WorkspaceStore.cs
@@ -70,13 +70,13 @@ namespace TopoMojo.Api.Data
                 .SingleOrDefaultAsync();
         }
 
-        public async Task DeleteWithTemplates(string id, Action<IEnumerable<Data.Template>> templateAction)
+        public async Task DeleteWithTemplates(string id, Func<IEnumerable<Data.Template>, Task> templateAction)
         {
             var entity = await Retrieve(id, q =>
                 q.Include(w => w.Templates)
             );
 
-            templateAction.Invoke(entity.Templates);
+            await templateAction.Invoke(entity.Templates);
 
             DbSet.Remove(entity);
 


### PR DESCRIPTION
Changes DeleteWithTemplates to accept Func<IEnumerable<Data.Template>, Task> instead of Action<IEnumerable<Template>> and awaits the Invoke call. This fixes the previous behavior, which implictly creates an async void fire-and-forget call, whose exceptions are not caught by the middleware and cause the application to crash.