### PR TITLE
Remove unused ApiKeyClients array setting from API

### DIFF
--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -13,11 +13,6 @@
 # Oidc__Audience = topomojo-api
 # Oidc__Authority = http://localhost:5000
 
-# ApiKeyClients__0__Id =
-# ApiKeyClients__0__Key =
-# ApiKeyClients__0__Scope =
-
-
 ####################
 ## Database
 ####################


### PR DESCRIPTION
The ApiKeyClients array setting is unused in the API. This removes the related lines from appsettings.conf.