### PR TITLE
Adds otel via Crucible Service Defaults

### DIFF
--- a/src/TopoMojo.Api/Startup.cs
+++ b/src/TopoMojo.Api/Startup.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.DataProtection;
 using TopoMojo.HostedServices;
+using Crucible.Common.ServiceDefaults;
 
 namespace TopoMojo.Api
 {
@@ -89,6 +90,17 @@ namespace TopoMojo.Api
             services.AddConfiguredAuthentication(Settings.Oidc);
             services.AddConfiguredAuthorization();
             services.AddSingleton(Settings);
+
+            // add Crucible Common Service Defaults with configuration from appsettings
+            services.AddServiceDefaults(Environment, Configuration, openTelemetryOptions =>
+            {
+                // Bind configuration from appsettings.json "OpenTelemetry" section
+                var telemetrySection = Configuration.GetSection("OpenTelemetry");
+                if (telemetrySection.Exists())
+                {
+                    telemetrySection.Bind(openTelemetryOptions);
+                }
+            });
         }
 
         public void Configure(IApplicationBuilder app)

--- a/src/TopoMojo.Api/TopoMojo.Api.csproj
+++ b/src/TopoMojo.Api/TopoMojo.Api.csproj
@@ -6,6 +6,7 @@
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>14</LangVersion>
+    <UserSecretsId>cmu-sei-crucible-topomojo-api</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -34,5 +35,6 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.1" />
+    <PackageReference Include="Crucible.Common.ServiceDefaults" Version="0.0.2" />
   </ItemGroup>
 </Project>

--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -174,6 +174,16 @@
 
 
 ####################
+## OpenTelemetry
+####################
+# OpenTelemetry__AddAlwaysOnTracingSampler = false
+# OpenTelemetry__AddConsoleExporter = false
+# OpenTelemetry__AddPrometheusExporter = false
+# OpenTelemetry__IncludeDefaultActivitySources = true
+# OpenTelemetry__IncludeDefaultMeters = true
+
+
+####################
 ## Headers
 ####################
 


### PR DESCRIPTION
Adds OpenTelemetry with Crucible ServiceDefaults implementation

- Adds ServiceDefaults settings to appsettings.conf, allowing the user to specify options for the ServiceDefaults library
- Adjust Startup.cs to configure Otel via ServiceDefaults


Tested using Crucible Dev Container - Deployed TopoMojo profile and observed all metrics, traces, and structured logs appearing in the Aspire Dashboard as intended.

Based changes made on the similar [PR to Alloy.Api](https://github.com/cmu-sei/Alloy.Api/pull/48) without the need to replace existing OpenTelemetry implementation.

Helm values will need to be updated to reflect the new OpenTelemetry settings. I can handle that in the Helm chart PR that is created once the changes are released.