### PR TITLE
Fix/aspire dashboard url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 wwwroot/lib/
+**/wwwroot/theme/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/src/TopoMojo.Api/Properties/launchSettings.json
+++ b/src/TopoMojo.Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "TopoMojo.Api": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "launchUrl": "api",
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/TopoMojo.Api/TopoMojo.Api.csproj
+++ b/src/TopoMojo.Api/TopoMojo.Api.csproj
@@ -5,6 +5,7 @@
     <Version>2.5.2</Version>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>cmu-sei-crucible-topomojo-api</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                            
  Adds launchSettings.json and modernizes project configuration to fix Aspire dashboard URL display and improve developer experience.                                                                   
                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                            
                                                                                                                                                                                                        
  ### 1. Add launchSettings.json for Aspire Dashboard                                                                                                                                                   
  - Created `Properties/launchSettings.json` with `launchUrl: "api"`                                                                                                                                    
  - Fixes Aspire dashboard showing root URL (`/`) instead of `/api` endpoint                                                                                                                            
  - Standardizes TopoMojo with other Crucible API projects                                                                                                                                              
  - Follows ASP.NET Core conventions for launch profiles                                                                                                                                                
                                                                                                                                                                                                        
  ### 2. Add UserSecretsId for Development Configuration
  - Added `<UserSecretsId>cmu-sei-crucible-topomojo-api</UserSecretsId>` to project file
  - Enables `dotnet user-secrets` command for local configuration
  - Allows Crucible AppHost to automatically configure database connection strings
  - Aligns with other Crucible API projects (Player, Caster, Steamfitter, etc.)

  ### 3. Ignore Theme Customization Files
  - Added `**/wwwroot/theme/` to `.gitignore`
  - Prevents custom theme background images from being tracked in version control
  - Allows per-deployment theme customization without repository changes

  ## Impact
  - **No production impact**: launchSettings.json and UserSecretsId are development-only features
  - **Improved DX**: Developers can now:
    - Click on TopoMojo API in Aspire dashboard and land on correct `/api` endpoint
    - Run TopoMojo API standalone with automatic database configuration via user secrets
  - **No breaking changes**: All changes are additive

  ## Testing
  - Verify Aspire dashboard displays `/api` endpoint for TopoMojo API
  - Confirm TopoMojo API launches correctly in both dev and prod modes
  - Test that theme files are properly ignored by git

  ## Related
  Part of Crucible-wide effort to standardize API launch configurations across all services.