### PR TITLE
Fix NullReferenceException when loading gamespaces with empty Variants arrays

### DIFF
--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
@@ -610,7 +610,7 @@ namespace TopoMojo.Api.Services
                     .FirstOrDefault()?.SetIndex ?? 0;
 
                 // map challenge to safe model
-                state.Challenge = MapChallengeView(spec, gamespace.Variant, activeSectionIndex);
+                state.Challenge = MapChallengeView(spec, activeSectionIndex);
             }
 
             return state;
@@ -973,11 +973,8 @@ namespace TopoMojo.Api.Services
 
         }
 
-        private ChallengeView MapChallengeView(ChallengeSpec spec, int variantIndex, int sectionIndex)
+        private ChallengeView MapChallengeView(ChallengeSpec spec, int sectionIndex)
         {
-            // Note: variantIndex parameter is unused. Challenge data comes from spec.Challenge (the selected variant),
-            // not from spec.Variants array. Removed dead code that accessed spec.Variants.ElementAt(variantIndex)
-            // to fix NullReferenceException when loading imported gamespaces with empty Variants arrays.
             var section = spec.Challenge.Sections?.ElementAtOrDefault(sectionIndex) ?? new SectionSpec();
 
             var challenge = new ChallengeView

--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
@@ -975,12 +975,9 @@ namespace TopoMojo.Api.Services
 
         private ChallengeView MapChallengeView(ChallengeSpec spec, int variantIndex, int sectionIndex)
         {
-            if (variantIndex > spec.Variants.Count)
-            {
-                variantIndex = 0;
-            }
-
-            var variant = spec.Variants.ElementAt(variantIndex);
+            // Note: variantIndex parameter is unused. Challenge data comes from spec.Challenge (the selected variant),
+            // not from spec.Variants array. Removed dead code that accessed spec.Variants.ElementAt(variantIndex)
+            // to fix NullReferenceException when loading imported gamespaces with empty Variants arrays.
             var section = spec.Challenge.Sections?.ElementAtOrDefault(sectionIndex) ?? new SectionSpec();
 
             var challenge = new ChallengeView


### PR DESCRIPTION
  ### Problem
  Loading gamespaces fails with `NullReferenceException` in `GamespaceService.MapChallengeView()` at line 983 when the gamespace has an empty `spec.Variants` array.

  This occurs when:
  - Workspace has variants defined but with no questions added
  - Infrastructure-only labs (VMs without graded challenges)
  - Incomplete challenge setup in the workspace editor

  ### Root Cause
  `MapChallengeView()` retrieved a `variant` from `spec.Variants.ElementAt(variantIndex)` but never used it. All challenge data comes from `spec.Challenge` (the selected variant), not from the `Variants` array. This dead code crashed when
  `Variants` was empty.

  The `variantIndex` parameter is passed but the retrieved `variant` variable is unused - the method only accesses `spec.Challenge.Sections`, never `variant.Sections`.

  ### Solution
  Removed the unused code that accessed `spec.Variants[variantIndex]`. The `variantIndex` parameter is now ignored (kept for API signature compatibility). Challenge data correctly comes from `spec.Challenge`.

  ### Testing

  **Prerequisites:**
  - Access to TopoMojo API
  - Workspace with empty challenge variant

  **Test Case 1: Create and load gamespace with empty challenge**
  1. Create workspace through UI
  2. Add variant but don't add questions
  3. Launch gamespace via Moodle or API
  4. Load gamespace via API - should return 200 (not 500)

  **Test Case 2: Verify affected gamespaces**
  ```bash
  # Before fix: returns 500 with NullReferenceException
  # After fix: returns 200 with gamespace data (empty challenge)
  curl -X GET "https://topomojo-api/api/gamespace/{gamespace-id}" \
    -H "Authorization: Bearer $TOKEN"

  Test Case 3: Verify normal gamespaces still work
  # Test gamespace with valid challenge questions
  curl -X GET "https://topomojo-api/api/gamespace/{normal-gamespace-id}" \
    -H "Authorization: Bearer $TOKEN"

  Expected Results:
  - All gamespace loads return 200 OK
  - Gamespaces with empty challenges show no questions (graceful)
  - Gamespaces with questions display correctly
  - No NullReferenceException in logs
  - VM infrastructure loads normally regardless of challenge state