### PR TITLE
Fix NSX deployment KeyNotFoundException on redeployment

### DIFF
--- a/src/TopoMojo.Hypervisor/vSphere/vSphereHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/vSphere/vSphereHypervisorService.cs
@@ -731,7 +731,7 @@ namespace TopoMojo.Hypervisor.vSphere
             {
                 if (existing.Any())
                 {
-                    await _hostCache.First().Value.Delete(ctx.Id);
+                    await DeleteAll(ctx.Id);
                     missing = [.. ctx.Templates];
                 }
 


### PR DESCRIPTION
When NSX networking is enabled and VMs already exist for a gamespace, DeployBatch attempts to delete existing VMs before redeploying with fresh network names. The code incorrectly called Delete(ctx.Id) passing a gamespace ID to VimClient.Delete() which expects a VM ID, causing KeyNotFoundException.

Changed to use DeleteAll(ctx.Id) which properly finds all VMs matching the gamespace ID and deletes each by its actual VM ID.

Fixes issue where users get "Failed to start event: no response from server" when relaunching labs with NSX networking enabled.