### PR TITLE
Update Proxmox client HTTP handling

### DIFF
--- a/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
+++ b/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
@@ -2,6 +2,8 @@
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
 
 using System.Reflection;
+using System.Net;
+using System.Net.Http;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using TopoMojo.Api;
@@ -145,6 +147,18 @@ namespace Microsoft.Extensions.DependencyInjection
                 .ConfigureHttpClient(client =>
                 {
                     client.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
+                });
+
+            // Named HttpClient for Corsinvest's PveClient. Supplying no client causes the SDK to
+            // create its own HttpClient and handler, which prevents handler pooling and can
+            // exhaust sockets when Proxmox clients are recreated.
+            services.AddHttpClient("proxmox")
+                .ConfigurePrimaryHttpMessageHandler(() =>
+                {
+                    return new HttpClientHandler
+                    {
+                        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                    };
                 });
 
             if (string.IsNullOrWhiteSpace(config.Url))

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -29,7 +30,8 @@ namespace TopoMojo.Hypervisor.Proxmox
             ILogger<ProxmoxClient> logger,
             IProxmoxNameService nameService,
             IProxmoxVlanManager vnetService,
-            Random random
+            Random random,
+            IHttpClientFactory httpClientFactory
         )
         {
             _logger = logger;
@@ -50,12 +52,12 @@ namespace TopoMojo.Hypervisor.Proxmox
             _config.Host = host;
             _hostPrefix = host.Split('.').FirstOrDefault();
 
-            _pveClient = new PveClient(host, port)
+            _pveClient = new PveClient(host, port, httpClientFactory.CreateClient("proxmox"))
             {
                 ApiToken = options.AccessToken
             };
 
-            _rootPveClient = new PveClient(host, port);
+            _rootPveClient = new PveClient(host, port, httpClientFactory.CreateClient("proxmox"));
 
             _nameService = nameService;
             _vlanManager = vnetService;

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using TopoMojo.Hypervisor.Extensions;
 
@@ -19,7 +20,8 @@ namespace TopoMojo.Hypervisor.Proxmox
             IProxmoxNameService nameService,
             IProxmoxVlanManager vlanManager,
             ILoggerFactory mill,
-            Random random
+            Random random,
+            IHttpClientFactory httpClientFactory
         )
         {
             _options = options;
@@ -36,7 +38,8 @@ namespace TopoMojo.Hypervisor.Proxmox
                 _mill.CreateLogger<ProxmoxClient>(),
                 nameService,
                 vlanManager,
-                random);
+                random,
+                httpClientFactory);
 
             _ = Task.Run(DeploymentHandler);
         }

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxVnetsClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Corsinvest.ProxmoxVE.Api;
@@ -32,7 +33,8 @@ namespace TopoMojo.Hypervisor.Proxmox
         (
             HypervisorServiceConfiguration hypervisorOptions,
             ILogger<ProxmoxVnetsClient> logger,
-            Random random
+            Random random,
+            IHttpClientFactory httpClientFactory
         )
         {
             _logger = logger;
@@ -46,7 +48,7 @@ namespace TopoMojo.Hypervisor.Proxmox
             }
             hypervisorOptions.Host = host;
 
-            _pveClient = new PveClient(host, port)
+            _pveClient = new PveClient(host, port, httpClientFactory.CreateClient("proxmox"))
             {
                 ApiToken = hypervisorOptions.AccessToken
             };

--- a/src/TopoMojo.Hypervisor/TopoMojo.Hypervisor.csproj
+++ b/src/TopoMojo.Hypervisor/TopoMojo.Hypervisor.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Corsinvest.ProxmoxVE.Api" Version="9.1.13" />
-    <PackageReference Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.13" />
+    <PackageReference Include="Corsinvest.ProxmoxVE.Api" Version="9.2.1" />
+    <PackageReference Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Updates TopoMojo to Corsinvest Proxmox API 9.2.1 and routes Proxmox requests through HttpClientFactory-managed clients to reduce socket exhaustion risk.

## User-facing changes

- Proxmox operations now reuse managed HTTP connection pools instead of creating unmanaged client/handler instances.
- Existing compressed-response handling is preserved.
- No configuration changes are required by this PR.

## Technical details

- Registered a named `proxmox` HttpClient with GZip/Deflate decompression.
- Injected `IHttpClientFactory` into the Proxmox hypervisor, API client, and VNet client.
- Updated all `PveClient` instances to receive factory-created HttpClient instances.
- Updated Corsinvest.ProxmoxVE.Api and Corsinvest.ProxmoxVE.Api.Extension from 9.1.13 to 9.2.1.
- Validation: `dotnet build src/TopoMojo.Api/TopoMojo.Api.csproj` succeeded with zero errors.