### PR TITLE
Honor Proxmox certificate validation setting

### DIFF
--- a/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
+++ b/src/TopoMojo.Api/Structure/TopoMojoStartupExtensions.cs
@@ -155,10 +155,18 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddHttpClient("proxmox")
                 .ConfigurePrimaryHttpMessageHandler(() =>
                 {
-                    return new HttpClientHandler
+                    var handler = new HttpClientHandler
                     {
                         AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
                     };
+
+                    if (config.IgnoreCertificateErrors)
+                    {
+                        handler.ServerCertificateCustomValidationCallback =
+                            HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                    }
+
+                    return handler;
                 });
 
             if (string.IsNullOrWhiteSpace(config.Url))


### PR DESCRIPTION
## ⚠️ Breaking changes

- Proxmox previously ignored `Pod__IgnoreCertificateErrors`, so its certificate validation behavior was not controlled by this setting and self-signed or otherwise untrusted certificates continued to work by default.
- This PR makes Proxmox honor `Pod__IgnoreCertificateErrors`, which defaults to `false`. Deployments relying on self-signed or otherwise untrusted Proxmox certificates must set `Pod__IgnoreCertificateErrors=true` or install a certificate trusted by the host.

## Summary

Applies TopoMojo's certificate-validation setting to Proxmox HTTP requests.

## User-facing changes

- Proxmox deployments can now explicitly control certificate validation with `Pod__IgnoreCertificateErrors`.
- Existing deployments that rely on self-signed or otherwise untrusted Proxmox certificates must set `Pod__IgnoreCertificateErrors=true` after this change.

## Technical details

- Configures the named `proxmox` HttpClient handler to bypass certificate validation only when `HypervisorServiceConfiguration.IgnoreCertificateErrors` is enabled.
- Leaves normal certificate validation enabled by default.
- Validation: `dotnet build src/TopoMojo.Api/TopoMojo.Api.csproj` succeeded with zero errors.