### PR TITLE
Add optional Proxmox HA deployment for CRS

### DIFF
--- a/docs/Proxmox.md
+++ b/docs/Proxmox.md
@@ -122,6 +122,8 @@ This section describes the appsettings that will need to be set to configure Top
   - Set this to `true` to skip TLS certificate validation when talking to the Proxmox API. Debug use only.
 - Pod__EnableHA
   - Set this to `true` to deploy virtual machines as cluster HA resources. See [High Availability and CRS](#high-availability-and-crs) below.
+- Pod__RequireHA
+  - Set this to `true` to fail a deployment when a virtual machine cannot be registered as an HA resource, rather than deploying it un-managed. Has no effect unless `Pod__EnableHA` is set.
 - Pod__HaAutoRebalance
   - Defaults to `true`. Allows CRS to migrate HA managed virtual machines during automatic rebalancing. Has no effect unless `Pod__EnableHA` is set.
 - Pod__HaMaxRestart
@@ -169,7 +171,7 @@ Setting `Pod__EnableHA = true` registers each deployed virtual machine as an HA 
 - **Power state is owned by the HA manager.** TopoMojo requests `started`/`stopped` on the HA resource rather than calling QEMU directly.
 - Restarting a virtual machine from TopoMojo issues a QEMU reset rather than a stop followed by a start, because the HA manager would collapse two state requests made in quick succession.
 - A virtual machine may not be on the node it was cloned to. TopoMojo resolves the current node before console, save, reconfigure, and delete operations, so this is transparent.
-- If registering an HA resource fails, the deployment still succeeds; the virtual machine simply will not be HA managed or rebalanced. This is logged as an error.
+- If registering an HA resource fails, the deployment still succeeds by default; the virtual machine simply will not be HA managed or rebalanced, and the failure is logged as an error. Such a virtual machine is otherwise fully usable, since power operations fall back to calling QEMU directly. Set `Pod__RequireHA = true` to treat this as a fatal error instead, in which case the clone is destroyed and the deployment fails.
 
 ## Guest Settings
 

--- a/docs/Proxmox.md
+++ b/docs/Proxmox.md
@@ -90,7 +90,7 @@ server {
     - The certificate location `/etc/pve/local` gets mounted by proxmox and the nginx service may fail with the indication nginx.conf is invalid if it tries to start before the pve-cluster.service loads.
     - Add `pve-cluster.service` at the end of the `After=` line.
     - At the bottom of the `[Unit]` section, add `Requires=pve-cluster.service`.
-    - After saving the file and exiting, type `systemctl daemon-reload` and press Enter.    
+    - After saving the file and exiting, type `systemctl daemon-reload` and press Enter.
 
 ## TopoMojo Setup
 
@@ -118,6 +118,16 @@ This section describes the appsettings that will need to be set to configure Top
   - The integer number of milliseconds TopoMojo will wait after a virtual network operation is initiated before reloading Proxmox's SDN. As reloading is a synchronous process that can take up 10 seconds, we offer this setting to reduce aggregate wait times by debouncing changes into batches.
 - Pod__Vlan__ResetDebounceMaxDuration
   - The integer number of milliseconds that describes the maximum amount of time TopoMojo will debounce before it reloads Proxmox's SDN following a network operation.
+- Pod__IgnoreCertificateErrors
+  - Set this to `true` to skip TLS certificate validation when talking to the Proxmox API. Debug use only.
+- Pod__EnableHA
+  - Set this to `true` to deploy virtual machines as cluster HA resources. See [High Availability and CRS](#high-availability-and-crs) below.
+- Pod__HaAutoRebalance
+  - Defaults to `true`. Allows CRS to migrate HA managed virtual machines during automatic rebalancing. Has no effect unless `Pod__EnableHA` is set.
+- Pod__HaMaxRestart
+  - The maximum number of times the HA manager will try to restart a virtual machine on a node after a failed start. Leave unset to use the Proxmox default. Has no effect unless `Pod__EnableHA` is set.
+- Pod__HaMaxRelocate
+  - The maximum number of times the HA manager will try to relocate a virtual machine that fails to start. Leave unset to use the Proxmox default. Has no effect unless `Pod__EnableHA` is set.
 
 #### ISOs
 
@@ -133,6 +143,33 @@ TopoMojo can optionally allow uploading of ISO files that can be mounted to virt
     - e.g. `/mnt/isos/template/iso`
 - FileUpload_SupportsSubFolders
     - Set this to `false` for Proxmox since Proxmox does not allow sub folders in it's ISO stores
+
+## High Availability and CRS
+
+By default TopoMojo picks a node itself when it deploys a virtual machine, and the virtual machine stays on that node for its lifetime. Proxmox's [Cluster Resource Scheduler (CRS)](https://pve.proxmox.com/wiki/High_Availability#ha_manager_crs) only places and rebalances virtual machines that are registered as cluster HA resources, so it has no effect on a default TopoMojo installation.
+
+Setting `Pod__EnableHA = true` registers each deployed virtual machine as an HA resource (`vm:<vmid>`) with `auto_rebalance` enabled, which lets CRS choose the node a virtual machine starts on and move it later as cluster load changes.
+
+### Prerequisites
+
+- A Proxmox **9** cluster. HA rules and the per-resource `auto_rebalance` option are PVE 9 features.
+- At least three nodes, so the cluster can hold quorum. The HA manager will fence resources on a node that loses quorum.
+- Virtual machine disks on **shared** storage (Ceph, NFS, iSCSI). TopoMojo deploys workspace and gamespace virtual machines as linked clones of a Proxmox template, and a linked clone on node-local storage cannot be migrated, so CRS will be unable to rebalance it.
+- CRS itself is configured on the Proxmox side, in `/etc/pve/datacenter.cfg`. For example:
+
+    ```
+    crs: ha=static,ha-rebalance-on-start=1
+    ```
+
+    `ha-rebalance-on-start=1` is what makes CRS pick the best node at the moment a virtual machine is started, rather than only on recovery.
+- Virtual machines with the VNC clipboard enabled (see [Clipboard Support](#clipboard-support)) can only be live migrated as of PVE 9.1, and only when the virtual machine's QEMU machine version is 10.1 or later. A virtual machine pinned to an older machine version will not be moved by CRS. See [Updating Existing Templates for Migration](#updating-existing-templates-for-migration) if you have templates created before PVE 9.1.
+
+### Behavior changes when HA is enabled
+
+- **Power state is owned by the HA manager.** TopoMojo requests `started`/`stopped` on the HA resource rather than calling QEMU directly.
+- Restarting a virtual machine from TopoMojo issues a QEMU reset rather than a stop followed by a start, because the HA manager would collapse two state requests made in quick succession.
+- A virtual machine may not be on the node it was cloned to. TopoMojo resolves the current node before console, save, reconfigure, and delete operations, so this is transparent.
+- If registering an HA resource fails, the deployment still succeeds; the virtual machine simply will not be HA managed or rebalanced. This is logged as an error.
 
 ## Guest Settings
 
@@ -160,7 +197,40 @@ TopoMojo supports clipboard access to Proxmox Virtual machines, if the appropria
 
 - On the Proxmox template, the VNC Clipboard must be enabled.
     - To do this, in the template's Hardware tab, Edit the Display and set Clipboard to VNC
-        - There is currently a known QEMU limitation where a virtual machine with the Clipboard set to VNC cannot be migrated to another Node. You may need to temporarily disable the VNC clipboard, perform the migration, and re-enable it if you need to move a vm to another Node.
+        - Before PVE 9.1, a virtual machine with the Clipboard set to VNC could not be migrated to another Node. PVE 9.1 allows live migration of these virtual machines, but only when the virtual machine's QEMU machine version is 10.1 or later. On older versions, or with an older machine version, you may need to temporarily disable the VNC clipboard, perform the migration, and re-enable it if you need to move a vm to another Node. See [Updating Existing Templates for Migration](#updating-existing-templates-for-migration).
 - The [SPICE Guest Tools](https://www.spice-space.org/download.html) must be installed in the virtual machines
     - This is installed by default on some Linux distributions.
     - This must be installed manually in Windows and has been tested and works the same as Linux clipboard support.
+
+### Updating Existing Templates for Migration
+
+If you are enabling [High Availability and CRS](#high-availability-and-crs) on a cluster with templates that predate PVE 9.1, those templates may produce clones that CRS cannot migrate. Live migration of a virtual machine with the VNC clipboard enabled requires a QEMU machine version of 10.1 or later, and a template's machine version is inherited by every clone made from it.
+
+Check what a template is currently using:
+
+```
+qm config <template_vmid> | grep machine
+```
+
+- If there is no `machine` line, the template is unpinned and clones will boot with the newest machine version the node's QEMU supports. Nothing needs to change, as long as every node in the cluster is on PVE 9.1 or later.
+- If the line names an older version, e.g. `machine: pc-q35-8.1`, clones are pinned to that version and will not be migratable with the VNC clipboard enabled.
+
+To move a pinned template forward:
+
+```
+qm set <template_vmid> --machine pc-q35-10.1
+```
+
+Alternatively, for non-Windows templates, remove the pin so clones always use the newest machine version available on the node they start on:
+
+```
+qm set <template_vmid> --delete machine
+```
+
+Caveats:
+
+- Proxmox pins the machine version at creation time for Windows guests because Windows is sensitive to virtual hardware changes, even across cold boots. Do not unpin a Windows template. Raising the pinned version on a Windows template can require driver reinstallation and may trigger reactivation, so back the template up first and boot a clone to verify it before publishing workspaces that use it.
+- Changing the template only affects clones made afterward. Virtual machines already deployed from the old template keep the old machine version; redeploy the workspace or gamespace to pick up the change.
+- The machine version of an existing snapshot cannot be changed.
+
+See [Machine Type](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_machine_type) in the Proxmox documentation for details.

--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -109,7 +109,7 @@
 ## vSphere Example. See docs/vSphere.md for details.
 ####################
 
-# Pod_HypervisorType = Vsphere
+# Pod__HypervisorType = Vsphere
 # Pod__DebugVerbose = false
 
 ## Example Url: https://vcenter.local or https://esxi[1-4].local (supports ranges)
@@ -177,6 +177,14 @@
 ## Set how long to wait for more network create/delete calls before reloading networking in Proxmox
 # Pod__Vlan__ResetDebounceDuration = 2000
 # Pod__Vlan__ResetDebounceMaxDuration = 5000
+
+## Register deployed vms as cluster HA resources, which lets the Proxmox Cluster Resource
+## Scheduler (CRS) place and rebalance them. Requires PVE 9 and shared vm storage, and is
+## also required for workspace Host Affinity on Proxmox. See docs/Proxmox.md.
+# Pod__EnableHA = false
+# Pod__HaAutoRebalance = true
+# Pod__HaMaxRestart =
+# Pod__HaMaxRelocate =
 
 ####################
 ## Logging

--- a/src/TopoMojo.Api/appsettings.conf
+++ b/src/TopoMojo.Api/appsettings.conf
@@ -182,6 +182,11 @@
 ## Scheduler (CRS) place and rebalance them. Requires PVE 9 and shared vm storage, and is
 ## also required for workspace Host Affinity on Proxmox. See docs/Proxmox.md.
 # Pod__EnableHA = false
+
+## Fail a deployment when a vm cannot be registered as an HA resource, rather than
+## deploying it un-managed. Has no effect unless Pod__EnableHA is set.
+# Pod__RequireHA = false
+
 # Pod__HaAutoRebalance = true
 # Pod__HaMaxRestart =
 # Pod__HaMaxRelocate =

--- a/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
+++ b/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
@@ -39,6 +39,12 @@ namespace TopoMojo.Hypervisor
         public bool EnableHA { get; set; }
 
         /// <summary>
+        /// Proxmox only. Fail a deployment when a vm cannot be registered as an HA resource, rather
+        /// than deploying it un-managed. Has no effect unless EnableHA is set.
+        /// </summary>
+        public bool RequireHA { get; set; }
+
+        /// <summary>
         /// Proxmox only. Allow CRS to migrate HA managed vms during automatic rebalancing.
         /// Has no effect unless EnableHA is set.
         /// </summary>

--- a/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
+++ b/src/TopoMojo.Hypervisor/HypervisorServiceConfiguration.cs
@@ -30,6 +30,32 @@ namespace TopoMojo.Hypervisor
         public bool DebugVerbose { get; set; }
         public bool IgnoreCertificateErrors { get; set; }
         public string SDNZone { get; set; } = "topomojo";
+
+        /// <summary>
+        /// Proxmox only. Register deployed vms as cluster HA resources, which is what allows
+        /// Proxmox's Cluster Resource Scheduler (CRS) to place and rebalance them.
+        /// Requires PVE 9 and shared vm storage. See docs/Proxmox.md.
+        /// </summary>
+        public bool EnableHA { get; set; }
+
+        /// <summary>
+        /// Proxmox only. Allow CRS to migrate HA managed vms during automatic rebalancing.
+        /// Has no effect unless EnableHA is set.
+        /// </summary>
+        public bool HaAutoRebalance { get; set; } = true;
+
+        /// <summary>
+        /// Proxmox only. Maximum tries to restart an HA resource on a node after a failed start.
+        /// Null uses the Proxmox default. Has no effect unless EnableHA is set.
+        /// </summary>
+        public int? HaMaxRestart { get; set; }
+
+        /// <summary>
+        /// Proxmox only. Maximum tries to relocate an HA resource that fails to start.
+        /// Null uses the Proxmox default. Has no effect unless EnableHA is set.
+        /// </summary>
+        public int? HaMaxRelocate { get; set; }
+
         public SddcConfiguration Sddc { get; set; } = new SddcConfiguration();
     }
 

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -61,7 +61,6 @@ namespace TopoMojo.Hypervisor.Proxmox
 
             _nameService = nameService;
             _vlanManager = vnetService;
-            _enableHA = _config.EnableHA;
             _ = MonitorSession();
             _ = MonitorTasks();
         }
@@ -80,7 +79,6 @@ namespace TopoMojo.Hypervisor.Proxmox
         private readonly PveClient _pveClient;
         private readonly PveClient _rootPveClient;
         private readonly Random _random;
-        private readonly bool _enableHA;
         private readonly object _lock = new();
         private const string deleteTag = "delete"; // tags are always lower-case
 
@@ -335,9 +333,17 @@ namespace TopoMojo.Hypervisor.Proxmox
 
             _vmCache.AddOrUpdate(vm.Id, vm, (k, v) => v = vm);
 
-            if (_enableHA)
+            if (_config.EnableHA && !await RegisterHA(nextId, template.Name) && _config.RequireHA)
             {
-                await RegisterHA(nextId, template.Name);
+                // the create call may have failed after the resource was created, and a vm cannot
+                // be destroyed while it is an HA resource
+                await UnregisterHA(nextId);
+                _vmCache.TryRemove(vm.Id, out _);
+
+                var destroyTask = await _pveClient.Nodes[targetNode].Qemu[nextId].DestroyVm();
+                await _pveClient.WaitForTaskToFinish(destroyTask);
+
+                throw new HypervisorException($"Could not register vm {template.Name} ({nextId}) as a Proxmox HA resource, and Pod__RequireHA is set.");
             }
 
             if (template.AutoStart)
@@ -355,7 +361,7 @@ namespace TopoMojo.Hypervisor.Proxmox
 
             // when a vm is HA managed, the HA manager owns its power state and will revert a
             // direct qemu start, so request the state change from it instead
-            if (!_enableHA || !await SetHAState(vm.Id, "started"))
+            if (!_config.EnableHA || !await SetHAState(vm.Id, "started"))
             {
                 var task = await _pveClient.Nodes[await GetCurrentNode(vm)].Qemu[vm.GetId()].Status.Start.VmStart();
                 await _pveClient.WaitForTaskToFinish(task);
@@ -372,7 +378,7 @@ namespace TopoMojo.Hypervisor.Proxmox
         {
             Vm vm = _vmCache[id];
 
-            if (!_enableHA || !await SetHAState(vm.Id, "stopped"))
+            if (!_config.EnableHA || !await SetHAState(vm.Id, "stopped"))
             {
                 var task = await _pveClient.Nodes[await GetCurrentNode(vm)].Qemu[vm.GetId()].Status.Stop.VmStop();
                 await _pveClient.WaitForTaskToFinish(task);
@@ -427,7 +433,7 @@ namespace TopoMojo.Hypervisor.Proxmox
             var status = await _pveClient.Nodes[node].Qemu[pveId].Status.Current.GetAsync();
 
             // a vm cannot be destroyed while it is an HA resource, so this has to come first
-            if (_enableHA)
+            if (_config.EnableHA)
             {
                 await UnregisterHA(vm.Id);
             }
@@ -691,10 +697,11 @@ namespace TopoMojo.Hypervisor.Proxmox
         /// qemu power operations on resources it manages.
         /// </summary>
         /// <remarks>
-        /// A failure here is logged but not thrown. An unmanaged vm still works; it just won't be
-        /// rebalanced, which is better than failing the whole deployment.
+        /// A failure is logged rather than thrown, and the caller decides what to do with it. An
+        /// unmanaged vm still works; it just won't be rebalanced. See RequireHA.
         /// </remarks>
-        private async Task RegisterHA(string id, string comment)
+        /// <returns>False if the vm could not be registered.</returns>
+        private async Task<bool> RegisterHA(string id, string comment)
         {
             try
             {
@@ -709,10 +716,14 @@ namespace TopoMojo.Hypervisor.Proxmox
                 await _pveClient.WaitForTaskToFinish(task);
 
                 _logger.LogDebug("registered ha resource {sid} (auto_rebalance: {rebalance})", GetSid(id), _config.HaAutoRebalance);
+
+                return true;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to register ha resource {sid}. The vm is deployed but will not be managed by the Proxmox HA manager or rebalanced by CRS.", GetSid(id));
+                _logger.LogError(ex, "Failed to register ha resource {sid}. The vm will not be managed by the Proxmox HA manager or rebalanced by CRS.", GetSid(id));
+
+                return false;
             }
         }
 
@@ -834,7 +845,7 @@ namespace TopoMojo.Hypervisor.Proxmox
         /// </summary>
         private async Task<string> GetCurrentNode(Vm vm)
         {
-            if (!_enableHA)
+            if (!_config.EnableHA)
                 return vm.Host;
 
             try

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -61,6 +61,7 @@ namespace TopoMojo.Hypervisor.Proxmox
 
             _nameService = nameService;
             _vlanManager = vnetService;
+            _enableHA = _config.EnableHA;
             _ = MonitorSession();
             _ = MonitorTasks();
         }
@@ -79,7 +80,7 @@ namespace TopoMojo.Hypervisor.Proxmox
         private readonly PveClient _pveClient;
         private readonly PveClient _rootPveClient;
         private readonly Random _random;
-        private readonly bool _enableHA = false;
+        private readonly bool _enableHA;
         private readonly object _lock = new();
         private const string deleteTag = "delete"; // tags are always lower-case
 
@@ -336,10 +337,10 @@ namespace TopoMojo.Hypervisor.Proxmox
 
             if (_enableHA)
             {
-                task = await _pveClient.Cluster.Ha.Resources.Create(nextId);
+                await RegisterHA(nextId, template.Name);
             }
 
-            if (template.AutoStart && task.IsSuccessStatusCode)
+            if (template.AutoStart)
             {
                 _logger.LogDebug("deploy: start vm...");
                 vm = await Start(vm.Id);
@@ -352,8 +353,14 @@ namespace TopoMojo.Hypervisor.Proxmox
         {
             Vm vm = _vmCache[id];
 
-            var task = await _pveClient.Nodes[vm.Host].Qemu[vm.GetId()].Status.Start.VmStart();
-            await _pveClient.WaitForTaskToFinish(task);
+            // when a vm is HA managed, the HA manager owns its power state and will revert a
+            // direct qemu start, so request the state change from it instead
+            if (!_enableHA || !await SetHAState(vm.Id, "started"))
+            {
+                var task = await _pveClient.Nodes[await GetCurrentNode(vm)].Qemu[vm.GetId()].Status.Start.VmStart();
+                await _pveClient.WaitForTaskToFinish(task);
+            }
+
             vm.State = VmPowerState.Running;
 
             _vmCache.TryUpdate(vm.Id, vm, vm);
@@ -365,9 +372,36 @@ namespace TopoMojo.Hypervisor.Proxmox
         {
             Vm vm = _vmCache[id];
 
-            var task = await _pveClient.Nodes[vm.Host].Qemu[vm.GetId()].Status.Stop.VmStop();
-            await _pveClient.WaitForTaskToFinish(task);
+            if (!_enableHA || !await SetHAState(vm.Id, "stopped"))
+            {
+                var task = await _pveClient.Nodes[await GetCurrentNode(vm)].Qemu[vm.GetId()].Status.Stop.VmStop();
+                await _pveClient.WaitForTaskToFinish(task);
+            }
+
             vm.State = VmPowerState.Off;
+
+            _vmCache.TryUpdate(vm.Id, vm, vm);
+
+            return vm;
+        }
+
+        /// <summary>
+        /// Resets a vm in place. Used instead of a stop/start pair for HA managed vms, where two
+        /// state requests in quick succession would be collapsed into a no-op by the HA manager.
+        /// </summary>
+        public async Task<Vm> Reset(string id)
+        {
+            Vm vm = _vmCache[id];
+            var node = await GetCurrentNode(vm);
+            var status = await _pveClient.Nodes[node].Qemu[vm.GetId()].Status.Current.GetAsync();
+
+            // a stopped vm can't be reset, so treat a reset of one as a start
+            if (!status.IsRunning)
+                return await Start(id);
+
+            var task = await _pveClient.Nodes[node].Qemu[vm.GetId()].Status.Reset.VmReset();
+            await _pveClient.WaitForTaskToFinish(task);
+            vm.State = VmPowerState.Running;
 
             _vmCache.TryUpdate(vm.Id, vm, vm);
 
@@ -389,12 +423,13 @@ namespace TopoMojo.Hypervisor.Proxmox
             Result task;
             var pveId = long.Parse(id);
             Vm vm = _vmCache[id];
-            var status = await _pveClient.Nodes[vm.Host].Qemu[pveId].Status.Current.GetAsync();
+            var node = await GetCurrentNode(vm);
+            var status = await _pveClient.Nodes[node].Qemu[pveId].Status.Current.GetAsync();
 
+            // a vm cannot be destroyed while it is an HA resource, so this has to come first
             if (_enableHA)
             {
-                task = await _pveClient.Cluster.Ha.Resources[pveId].Delete();
-                await _pveClient.WaitForTaskToFinish(task);
+                await UnregisterHA(vm.Id);
             }
 
             if (status.IsRunning)
@@ -403,7 +438,7 @@ namespace TopoMojo.Hypervisor.Proxmox
                 await _pveClient.WaitForTaskToFinish(task);
             }
 
-            task = await _pveClient.Nodes[vm.Host].Qemu[id].DestroyVm();
+            task = await _pveClient.Nodes[node].Qemu[id].DestroyVm();
             await _pveClient.WaitForTaskToFinish(task);
             vm.Status = "initialized";
 
@@ -420,12 +455,13 @@ namespace TopoMojo.Hypervisor.Proxmox
             string url;
             string ticket;
             var vm = _vmCache[id];
+            var node = await GetCurrentNode(vm);
 
-            var result = await _pveClient.Nodes[vm.Host].Qemu[id].Vncproxy.Vncproxy(websocket: true);
+            var result = await _pveClient.Nodes[node].Qemu[id].Vncproxy.Vncproxy(websocket: true);
 
             if (result.IsSuccessStatusCode)
             {
-                string urlFragment = $"/api2/json/nodes/{vm.Host}/qemu/{id}/vncwebsocket?port={result.Response.data.port}&vncticket={WebUtility.UrlEncode(result.Response.data.ticket)}";
+                string urlFragment = $"/api2/json/nodes/{node}/qemu/{id}/vncwebsocket?port={result.Response.data.port}&vncticket={WebUtility.UrlEncode(result.Response.data.ticket)}";
                 url = $"wss://{_config.Host}{urlFragment}";
                 ticket = result.Response.data.ticket;
             }
@@ -443,10 +479,11 @@ namespace TopoMojo.Hypervisor.Proxmox
 
             if (vm != null)
             {
-                var config = await _pveClient.Nodes[vm.Host].Qemu[vm.Id].Config.GetAsync();
+                var node = await GetCurrentNode(vm);
+                var config = await _pveClient.Nodes[node].Qemu[vm.Id].Config.GetAsync();
 
                 var disk = config.Disks.ElementAt(0);
-                var storageItems = await _pveClient.Nodes[vm.Host].Storage[disk.Storage].Content.GetAsync();
+                var storageItems = await _pveClient.Nodes[node].Storage[disk.Storage].Content.GetAsync();
 
                 var pveDisk = storageItems.Where(x => disk.FileName == x.FileName).FirstOrDefault();
 
@@ -470,7 +507,7 @@ namespace TopoMojo.Hypervisor.Proxmox
                         {
                             // Full Clone vm
                             var nextId = int.Parse(await GetNextId());
-                            var task = await _pveClient.Nodes[vm.Host].Qemu[vm.Id].Clone.CloneVm(newid: nextId, full: true, target: template.Host, name: template.Name);
+                            var task = await _pveClient.Nodes[node].Qemu[vm.Id].Clone.CloneVm(newid: nextId, full: true, target: template.Host, name: template.Name);
 
                             var t = new PveNodeTask { Id = task.Response.data, Action = "saving", WhenCreated = DateTimeOffset.UtcNow };
                             vm.Task = new VmTask { Name = "saving", WhenCreated = DateTime.UtcNow, Progress = t.Progress };
@@ -546,8 +583,8 @@ namespace TopoMojo.Hypervisor.Proxmox
             return isos;
         }
 
-        public Task<PveVmConfig> GetVmConfig(Vm vm)
-            => GetVmConfig(vm.Host, vm.GetId());
+        public async Task<PveVmConfig> GetVmConfig(Vm vm)
+            => await GetVmConfig(await GetCurrentNode(vm), vm.GetId());
 
         public async Task<PveVmConfig> GetVmConfig(string node, long vmId)
         {
@@ -604,7 +641,8 @@ namespace TopoMojo.Hypervisor.Proxmox
         public async Task<Vm> PushVmConfigUpdate(long vmId, PveVmUpdateConfig update)
         {
             var vm = _vmCache[vmId.ToString()];
-            var currentConfig = await GetVmConfig(vm);
+            var node = await GetCurrentNode(vm);
+            var currentConfig = await GetVmConfig(node, vm.GetId());
 
             // if there are any net assignment updates, we need to resolve their IDs from the names
             // passed in. We make a new dictionary to hold them rather than mutate the argument.
@@ -629,7 +667,7 @@ namespace TopoMojo.Hypervisor.Proxmox
             }
 
             var updateTask = await _pveClient
-                .Nodes[vm.Host]
+                .Nodes[node]
                 .Qemu[vm.Id]
                 .Config
                 .UpdateVmAsync
@@ -639,6 +677,184 @@ namespace TopoMojo.Hypervisor.Proxmox
 
             await _pveClient.WaitForTaskToFinish(updateTask);
             return vm;
+        }
+
+        /// <summary>
+        /// The HA resource id ("sid") of a vm, e.g. vm:100.
+        /// </summary>
+        private static string GetSid(string id) => $"vm:{id}";
+
+        /// <summary>
+        /// Registers a vm as a cluster HA resource so that Proxmox's Cluster Resource Scheduler can
+        /// place and rebalance it. Resources are created stopped; power state is then driven through
+        /// the HA manager (see <see cref="SetHAState"/>), because the HA manager reverts direct
+        /// qemu power operations on resources it manages.
+        /// </summary>
+        /// <remarks>
+        /// A failure here is logged but not thrown. An unmanaged vm still works; it just won't be
+        /// rebalanced, which is better than failing the whole deployment.
+        /// </remarks>
+        private async Task RegisterHA(string id, string comment)
+        {
+            try
+            {
+                var task = await _pveClient.Cluster.Ha.Resources.Create(
+                    GetSid(id),
+                    auto_rebalance: _config.HaAutoRebalance,
+                    comment: comment,
+                    max_relocate: _config.HaMaxRelocate,
+                    max_restart: _config.HaMaxRestart,
+                    state: "stopped",
+                    type: "vm");
+                await _pveClient.WaitForTaskToFinish(task);
+
+                _logger.LogDebug("registered ha resource {sid} (auto_rebalance: {rebalance})", GetSid(id), _config.HaAutoRebalance);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to register ha resource {sid}. The vm is deployed but will not be managed by the Proxmox HA manager or rebalanced by CRS.", GetSid(id));
+            }
+        }
+
+        /// <summary>
+        /// Removes a vm from cluster HA management. Purging also removes it from any HA rule that
+        /// references it, deleting the rule if it was the rule's only resource.
+        /// </summary>
+        /// <returns>False if the vm was not an HA resource.</returns>
+        private async Task<bool> UnregisterHA(string id)
+        {
+            try
+            {
+                var task = await _pveClient.Cluster.Ha.Resources[GetSid(id)].Delete(purge: true);
+                await _pveClient.WaitForTaskToFinish(task);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // most likely the vm was deployed before HA was enabled, so there is nothing to remove
+                _logger.LogDebug(ex, "Could not delete ha resource {sid}", GetSid(id));
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Requests a power state of the HA manager for a vm it manages.
+        /// </summary>
+        /// <param name="state">started or stopped</param>
+        /// <returns>False if the vm was not an HA resource, so the caller can fall back to a direct qemu operation.</returns>
+        private async Task<bool> SetHAState(string id, string state)
+        {
+            try
+            {
+                var task = await _pveClient.Cluster.Ha.Resources[GetSid(id)].Update(state: state);
+                await _pveClient.WaitForTaskToFinish(task);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // most likely the vm was deployed before HA was enabled
+                _logger.LogWarning(ex, "Could not request ha state {state} for {sid}, falling back to a direct power operation", state, GetSid(id));
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Keeps the vms of an isolation on the same node using a positive HA resource-affinity rule.
+        /// Requires the vms to be HA resources, so it is only meaningful when EnableHA is set.
+        /// </summary>
+        /// <remarks>The rule is cleaned up by <see cref="UnregisterHA"/> when the last member vm is deleted.</remarks>
+        public async Task SetPositiveAffinity(string isolationTag, Vm[] vms)
+        {
+            if (vms.Length == 0)
+                return;
+
+            var rule = GetAffinityRuleId(isolationTag);
+            var existing = await GetAffinityRuleResources(rule);
+
+            // vms of an isolation can be deployed one at a time, so add to the rule rather than replace it
+            var sids = existing
+                .Union(vms.Select(vm => GetSid(vm.Id)))
+                .ToArray();
+
+            if (sids.Length < 2)
+            {
+                _logger.LogDebug("skipping ha affinity {rule}, an isolation of one vm has nothing to keep together", rule);
+                return;
+            }
+
+            var resources = string.Join(',', sids);
+
+            var task = existing.Length != 0
+                ? await _pveClient.Cluster.Ha.Rules[rule].UpdateRule("resource-affinity", resources: resources)
+                : await _pveClient.Cluster.Ha.Rules.CreateRule(
+                    resources,
+                    rule,
+                    "resource-affinity",
+                    affinity: "positive",
+                    comment: $"topomojo isolation {isolationTag}");
+
+            await _pveClient.WaitForTaskToFinish(task);
+
+            _logger.LogDebug("set positive ha affinity {rule} for {resources}", rule, resources);
+        }
+
+        /// <summary>
+        /// The resource ids already in an HA rule, or an empty array if the rule doesn't exist.
+        /// </summary>
+        private async Task<string[]> GetAffinityRuleResources(string rule)
+        {
+            try
+            {
+                var result = await _pveClient.Cluster.Ha.Rules[rule].ReadRule();
+
+                if (!result.IsSuccessStatusCode)
+                    return [];
+
+                return (((string)result.Response.data.resources) ?? "")
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Could not read ha rule {rule}", rule);
+                return [];
+            }
+        }
+
+        /// <summary>
+        /// Proxmox config ids allow only letters, numbers, dashes, underscores and periods.
+        /// </summary>
+        private static string GetAffinityRuleId(string isolationTag)
+            => $"topomojo-{InvalidPveIdCharsRegex().Replace(isolationTag ?? "", "-")}";
+
+        /// <summary>
+        /// Resolves the node a vm is currently running on. CRS can migrate HA managed vms at any time,
+        /// and the vm cache only catches up on its next refresh, so the cached node can be stale.
+        /// </summary>
+        private async Task<string> GetCurrentNode(Vm vm)
+        {
+            if (!_enableHA)
+                return vm.Host;
+
+            try
+            {
+                var pveVm = await _pveClient.GetVmAsync(vm.Id);
+
+                if (pveVm != null && !string.IsNullOrEmpty(pveVm.Node) && pveVm.Node != vm.Host)
+                {
+                    _logger.LogDebug("vm {name} ({id}) moved from {old} to {new}", vm.Name, vm.Id, vm.Host, pveVm.Node);
+                    vm.Host = pveVm.Node;
+                    _vmCache.TryUpdate(vm.Id, vm, vm);
+                }
+
+                return vm.Host;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not resolve the current node of vm {id}, using {host}", vm.Id, vm.Host);
+                return vm.Host;
+            }
         }
 
         /// <summary>
@@ -660,7 +876,7 @@ namespace TopoMojo.Hypervisor.Proxmox
 
                 if (targetNodes.Any())
                 {
-                    targetNode = targetNodes.ElementAt(_random.Next(0, targetNodes.Count() - 1));
+                    targetNode = targetNodes.ElementAt(_random.Next(0, targetNodes.Count()));
                 }
                 else
                 {
@@ -679,7 +895,7 @@ namespace TopoMojo.Hypervisor.Proxmox
         private async Task<string> GetRandomNode()
         {
             var nodes = await _pveClient.GetNodesAsync();
-            var randomNum = _random.Next(0, nodes.Count() - 1);
+            var randomNum = _random.Next(0, nodes.Count());
             return nodes.ElementAt(randomNum).Node;
         }
 
@@ -998,6 +1214,9 @@ namespace TopoMojo.Hypervisor.Proxmox
             }
             // _logger.LogDebug("taskMonitor ended.");
         }
+
+        [GeneratedRegex(@"[^A-Za-z0-9_.\-]")]
+        private static partial Regex InvalidPveIdCharsRegex();
 
         [GeneratedRegex(@"net(\d)+")]
         private static partial Regex NicDataRegex();

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
@@ -268,6 +268,12 @@ namespace TopoMojo.Hypervisor.Proxmox
             return await _pveClient.Stop(vm.Id);
         }
 
+        private async Task<Vm> Reset(string id)
+        {
+            var vm = await LoadVm(id);
+            return await _pveClient.Reset(vm.Id);
+        }
+
         public async Task<Vm> Save(string id)
         {
             var vm = await LoadVm(id);
@@ -326,8 +332,16 @@ namespace TopoMojo.Hypervisor.Proxmox
                     break;
 
                 case VmOperationType.Reset:
-                    _ = await Stop(op.Id);
-                    vm = await Start(op.Id);
+                    if (Options.EnableHA)
+                    {
+                        // a stop/start pair would be collapsed into a no-op by the HA manager
+                        vm = await Reset(op.Id);
+                    }
+                    else
+                    {
+                        _ = await Stop(op.Id);
+                        vm = await Start(op.Id);
+                    }
                     break;
 
                 case VmOperationType.Stop:
@@ -387,9 +401,21 @@ namespace TopoMojo.Hypervisor.Proxmox
             return await _pveClient.PushVmConfigUpdate(vmId, configUpdate);
         }
 
-        public Task SetAffinity(string isolationTag, Vm[] vms, bool start)
+        public async Task SetAffinity(string isolationTag, Vm[] vms, bool start)
         {
-            throw new NotImplementedException();
+            // affinity is expressed as an HA resource-affinity rule, so the vms have to be HA resources
+            if (Options.EnableHA)
+            {
+                _logger.LogDebug("setaffinity: setting affinity for {tag}", isolationTag);
+                await _pveClient.SetPositiveAffinity(isolationTag, vms);
+            }
+            else
+            {
+                _logger.LogWarning("setaffinity: host affinity on Proxmox requires Pod__EnableHA, ignoring for {tag}", isolationTag);
+            }
+
+            if (start)
+                await Task.WhenAll(vms.Select(vm => Start(vm.Id)));
         }
 
         public async Task<Vm> Refresh(VmTemplate template)
@@ -506,6 +532,13 @@ namespace TopoMojo.Hypervisor.Proxmox
                 tasks.Add(Deploy(template, ctx.Privileged));
 
             await Task.WhenAll(tasks.ToArray());
+
+            if (ctx.Affinity)
+            {
+                // templates with host affinity are deployed with AutoStart off, so SetAffinity
+                // starts them after the rule is in place
+                await SetAffinity(ctx.Id, [.. tasks.Select(t => t.Result).Where(vm => vm != null)], true);
+            }
         }
 
         public async Task Deploy(DeploymentContext ctx, bool wait = false)


### PR DESCRIPTION
## Summary

Adds optional support for deploying Proxmox virtual machines as cluster HA resources, so that Proxmox VE 9's Cluster Resource Scheduler (CRS) can place and rebalance TopoMojo's virtual machines. CRS only acts on virtual machines registered with `ha-manager`, so previously a Proxmox-backed TopoMojo got no benefit from it: TopoMojo picked a node itself at deploy time and the virtual machine stayed there for its lifetime.

The feature is off by default. With `Pod__EnableHA` unset, behavior is unchanged.

## User-facing changes

- **New setting `Pod__EnableHA`** (default `false`). When enabled, each deployed virtual machine is registered as an HA resource (`vm:<vmid>`) with `auto_rebalance` on, letting CRS choose the node a virtual machine starts on and migrate it later as cluster load changes.
- **New setting `Pod__RequireHA`** (default `false`). By default, a virtual machine that cannot be registered as an HA resource is deployed un-managed and the failure is logged as an error; such a virtual machine is still fully usable, since power operations fall back to calling QEMU directly. Enable this to treat the failure as fatal instead, in which case the clone is destroyed and the deployment fails.
- **New settings `Pod__HaAutoRebalance`** (default `true`), **`Pod__HaMaxRestart`**, and **`Pod__HaMaxRelocate`** to tune HA behavior. The two limits fall back to the Proxmox defaults when unset.
- **Requires PVE 9 and shared virtual machine storage.** TopoMojo deploys linked clones, and a linked clone on node-local storage cannot be migrated, so CRS would be unable to rebalance it. Documented as a prerequisite; there is no runtime check.
- **Restarting a virtual machine no longer throws on Proxmox** when a workspace has host affinity set. `SetAffinity` was previously an unimplemented stub that raised `NotImplementedException` from `POST /api/vm-template/{id}`.
- **New documentation** in `docs/Proxmox.md`: a "High Availability and CRS" section covering prerequisites and behavior changes, and an "Updating Existing Templates for Migration" section on the QEMU machine version requirement for migrating virtual machines with the VNC clipboard enabled.

## Technical details

- `HypervisorServiceConfiguration` gains `EnableHA`, `HaAutoRebalance`, `HaMaxRestart`, and `HaMaxRelocate`. Names are flat and unprefixed to match the existing convention in this shared class, where `SDNZone` and `Vlan.ResetDebounce*` are already Proxmox-only; provider scope is conveyed by XML doc comments and by documenting them under `docs/Proxmox.md`.
- `ProxmoxClient` drops the hardcoded `private readonly bool _enableHA = false` field entirely and reads `_config.EnableHA` directly, which activates the previously dead HA code path without keeping a second copy of config state.
- HA helpers added to `ProxmoxClient`: `RegisterHA`, `UnregisterHA` (with `purge: true`), `SetHAState`, and `GetSid`. `RegisterHA` logs and returns false rather than throwing, and `Deploy` decides what to do with that based on `Pod__RequireHA`. In the strict case it unregisters (the create call can fail after the resource was created, and a virtual machine cannot be destroyed while it is an HA resource), drops the cache entry, destroys the clone, and throws `HypervisorException` — mirroring the existing reconfigure-failure cleanup path in the same method.
- `Start`/`Stop` request `started`/`stopped` on the HA resource and fall back to the direct qemu call when the resource isn't HA-managed, which covers virtual machines deployed before the flag was turned on.
- New `Reset` issues `qemu/status/reset`. `ChangeState`'s reset case used a stop followed by a start, which the CRM would collapse into a single no-op state write. A reset of a stopped virtual machine delegates to `Start`, matching what the old stop/start path tolerated.
- New `GetCurrentNode(Vm)` resolves the live node via `/cluster/resources` and refreshes the cache entry when a virtual machine has moved. The vm cache is only reconciled every 30s, so once CRS can migrate a virtual machine the cached `vm.Host` goes stale and node-pinned calls hit the wrong node. Used by console, save, reconfigure, delete, and the qemu power fallbacks; it short-circuits to `vm.Host` when HA is off.
- `Delete` unregisters the HA resource before destroying the virtual machine, since a virtual machine cannot be destroyed while it is an HA resource, and tolerates a missing resource.
- `SetAffinity` is implemented as a positive [HA resource-affinity rule](https://pve.proxmox.com/wiki/High_Availability#ha_manager_rules) named `topomojo-<isolation tag>` (sanitized to PVE's id charset). Because virtual machines of an isolation can be deployed one at a time, the rule is read and unioned rather than replaced, and no rule is created for an isolation of one virtual machine. `Delete(purge: true)` on the last member removes the rule, so no explicit teardown is needed. HA rules are PVE 9 only; the deprecated HA groups API is not used.
- `DeployBatch` now honors `DeploymentContext.Affinity`, which the Proxmox path silently ignored. Templates with host affinity are deployed with `AutoStart` off, so `SetAffinity` starts them once the rule is in place.
- Fixed a latent bug in `Deploy` where the HA result was assigned to the same local the next line tested, making `template.AutoStart` conditional on HA registration succeeding.
- Fixed `GetTargetNode`/`GetRandomNode` using `_random.Next(0, count - 1)`, whose exclusive upper bound never selected the last node. Node spread matters more now that HA/CRS is in play.
- Corrected an outdated claim in `docs/Proxmox.md` that virtual machines with the VNC clipboard enabled cannot be migrated. PVE 9.1 allows live migration of these virtual machines when the QEMU machine version is 10.1 or later.
- Fixed a `# Pod_HypervisorType` single-underscore typo in `appsettings.conf`.

