### PR TITLE
Fix iso-usage 500 error from DateTimeOffset.Year in EF query

### DIFF
--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceStore.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceStore.cs
@@ -173,7 +173,10 @@ namespace TopoMojo.Api.Data
             var now = DateTimeOffset.UtcNow;
 
             return await DbSet
-                .Where(g => g.StartTime.Year > 1 && g.EndTime.Year <= 1 && g.ExpirationTime >= now)
+                .Where(g =>
+                    g.StartTime > DateTimeOffset.MinValue &&
+                    g.EndTime <= DateTimeOffset.MinValue &&
+                    g.ExpirationTime >= now)
                 .Where(g => g.Workspace.Templates.Any(t => t.Iso == isoPath))
                 .ToArrayAsync();
         }


### PR DESCRIPTION
## Summary

`GET api/workspace/{workspaceId}/iso-usage` returned a `500` instead of an `IsoUsageReport`
whenever the queried ISO was actually in use. The endpoint only worked for *unused* ISOs, so
the usage report — the thing it exists to produce — was never retrievable.

Introduced in #114 alongside the endpoint itself.

## User-facing changes

- `GET api/workspace/{workspaceId}/iso-usage` now returns `200` with the populated
  `templates[]` / `activeGamespaces[]` report for an ISO that is in use.
- No change to the response shape, route, or auth behavior.
- Any UI flow that checks ISO usage before offering delete (`DELETE api/workspace/{id}/iso`)
  now gets a real answer instead of a server error.

## Technical details

`GamespaceStore.FindActiveByIso` filtered on `g.StartTime.Year > 1 && g.EndTime.Year <= 1`.
EF Core translates `.Year` to `CAST(date_part('year', ... AT TIME ZONE 'UTC') AS integer)`.
Npgsql maps `DateTimeOffset.MinValue`/`MaxValue` onto Postgres `-infinity`/`infinity`, and
`date_part` over those yields `±Infinity`, which overflows the `integer` cast:

```
Npgsql.PostgresException: 22003: integer out of range
  Routine: dtoi4
  at TopoMojo.Api.Data.GamespaceStore.FindActiveByIso(String isoPath)
```

Gamespaces that have not ended store `MinValue` in `EndTime`, so any row that survived the
template filter tripped the cast. It presented as "only fails when the ISO is in use"
because with no matching template Postgres evaluates the
`EXISTS (SELECT 1 FROM Templates ...)` predicate first and filters every row out before the
`date_part` cast is ever computed.

The fix uses direct `timestamptz` comparisons, which handle `infinity` correctly, matching
the pattern already used in `LoadActiveByContext` and `IsBelowGamespaceLimit` in the same
file. `Year > 1` ⇔ `> MinValue` and `Year <= 1` ⇔ `<= MinValue` for these sentinel-valued
columns, so the predicate is semantically unchanged.

This is the same class of bug that `3750af6` ("Fix datetime min value evaluation") already
corrected across `JanitorService`, `TransferService`, `DispatchService`, `GamespaceStore`,
and `WorkspaceStore`; #114 reintroduced it in a new form. The remaining `.Year` uses
(`Gamespace.HasStarted`/`HasEnded`, `GamespaceService.cs:546`) run in memory on materialized
entities rather than in EF query translation, and are unaffected.

## Verification

Reproduced against a local Postgres-backed stack: the endpoint returned `500` with the
`22003`/`dtoi4` exception for an in-use ISO before the change, and `200` with the populated
report after. Unused-ISO and public-bin (`00000000-0000-0000-0000-000000000000`) cases still
return `200`.