### PR TITLE
Fix Proxmox Guest Settings escaping

### DIFF
--- a/docs/Proxmox.md
+++ b/docs/Proxmox.md
@@ -197,6 +197,23 @@ In Proxmox, a similar functionality is achieved using the QEMU Firmware Configur
 
 Note: This currently only works on Linux Guests. There is an open source [Windows driver](https://github.com/virtio-win/kvm-guest-drivers-windows/tree/master/fwcfg64) that has some basic fw_cfg support, but does not support reading user-defined /opt values at this time.
 
+### Value syntax
+
+Write one `key=value` per line. Only the first `=` on a line is the separator, so the value may contain further `=` characters. A line whose key begins with `#` is treated as a comment and skipped.
+
+Values are escaped for both parsers they pass through on the way to the guest, so commas, spaces, single and double quotes, and backslashes all arrive verbatim — no manual escaping is needed. A `;` is ordinary data in a Proxmox value; note that this differs from vSphere, where `;` separates settings in addition to newlines.
+
+### Implementation note
+
+The `args` property that carries the `-fw_cfg` arguments is parsed twice, and each layer needs a different escape:
+
+1. Proxmox splits `args` into argv with `PVE::Tools::split_args`, which is `Text::ParseWords::shellwords`. It honours quotes and then strips them.
+2. QEMU parses one argv element with `QemuOpts`, which splits on commas. It has no quote handling at all, so quoting cannot protect a comma; its only escape is a doubled comma, which QEMU collapses again before the guest reads the value.
+
+Because the layers do not meet, `ProxmoxFwCfg` always applies both: it doubles every literal comma, then single-quotes the whole argument. Single quotes are used rather than double quotes because they preserve backslashes and are unaffected by a double quote in the value.
+
+### Root user requirement
+
 As described in the Settings section, this currently requires the use of the root user and password. There is a [patch](https://bugzilla.proxmox.com/show_bug.cgi?id=4068) available for Proxmox that would make this no longer necessary, but it has not been merged into a release. Currently, if a root password is not provided, Guest Settings will be skipped when virtual machines are deployed.
 
 ## Using Proxmox Templates

--- a/src/TopoMojo.Api.Tests/TemplateGuestSettingsTests.cs
+++ b/src/TopoMojo.Api.Tests/TemplateGuestSettingsTests.cs
@@ -1,35 +1,44 @@
 // Copyright 2025 Carnegie Mellon University. All Rights Reserved.
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using TopoMojo.Api.Services;
 using TopoMojo.Hypervisor;
+using TopoMojo.Hypervisor.Proxmox;
+using TopoMojo.Hypervisor.vMock;
+using TopoMojo.Hypervisor.vSphere;
 using Xunit;
 
 namespace TopoMojo.Api.Tests;
 
 public class TemplateGuestSettingsTests
 {
-    // On Proxmox a ';' is ordinary data in a Guest Setting value, so splitting on it truncated the
-    // value at the first ';' and leaked the remainder as its own bogus sibling setting.
+    // The separator sets the hypervisors declare, named here so each test says which syntax it
+    // is exercising rather than passing a bare bool.
+    private static readonly char[] WithSemicolon = [';', '\n', '\r'];
+    private static readonly char[] NewlinesOnly = ['\n', '\r'];
+
+    public static TheoryData<char[]> AllSeparatorSets => [WithSemicolon, NewlinesOnly];
+
+    // Where ';' is not a separator it is ordinary data in a value, so the value must survive whole.
     [Theory]
     [InlineData("hosts=10.7.42.11 web;10.7.42.12 db", "guestinfo.hosts", "10.7.42.11 web;10.7.42.12 db")]
     [InlineData("dhcp=x=1;y=2", "guestinfo.dhcp", "x=1;y=2")]
-    public void AddGuestSettings_WithoutSemicolonSeparator_KeepsTheWholeValue(
+    public void AddGuestSettings_WhenSemicolonIsNotASeparator_KeepsTheWholeValue(
         string guestinfo, string expectedKey, string expectedValue)
     {
-        var settings = Parse(guestinfo, allowSemicolonSeparator: false);
+        var settings = Parse(guestinfo, NewlinesOnly);
 
         var setting = Assert.Single(settings);
         Assert.Equal(expectedKey, setting.Key);
         Assert.Equal(expectedValue, setting.Value);
     }
 
-    // Pins the legacy vSphere behavior, which is unchanged.
     [Fact]
-    public void AddGuestSettings_WithSemicolonSeparator_StillSplitsAndDropsTheRemainder()
+    public void AddGuestSettings_WhenSemicolonIsASeparator_SplitsOnIt()
     {
-        var settings = Parse("hosts=a;b", allowSemicolonSeparator: true);
+        var settings = Parse("hosts=a;b", WithSemicolon);
 
         var setting = Assert.Single(settings);
         Assert.Equal("guestinfo.hosts", setting.Key);
@@ -37,9 +46,9 @@ public class TemplateGuestSettingsTests
     }
 
     [Fact]
-    public void AddGuestSettings_WithSemicolonSeparator_StillLeaksASiblingKey()
+    public void AddGuestSettings_WhenSemicolonIsASeparator_TreatsTheRemainderAsItsOwnSetting()
     {
-        var settings = Parse("dhcp=x=1;y=2", allowSemicolonSeparator: true);
+        var settings = Parse("dhcp=x=1;y=2", WithSemicolon);
 
         Assert.Equal(2, settings.Length);
         Assert.Equal("x=1", settings.Single(x => x.Key == "guestinfo.dhcp").Value);
@@ -47,11 +56,10 @@ public class TemplateGuestSettingsTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void AddGuestSettings_SplitsOnNewlinesInEitherMode(bool allowSemicolonSeparator)
+    [MemberData(nameof(AllSeparatorSets))]
+    public void AddGuestSettings_SplitsOnNewlines(char[] separators)
     {
-        var settings = Parse("a=1\nb=2\r\nc=3", allowSemicolonSeparator);
+        var settings = Parse("a=1\nb=2\r\nc=3", separators);
 
         Assert.Equal(3, settings.Length);
         Assert.Equal("1", settings.Single(x => x.Key == "guestinfo.a").Value);
@@ -60,11 +68,10 @@ public class TemplateGuestSettingsTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void AddGuestSettings_SkipsCommentLinesInEitherMode(bool allowSemicolonSeparator)
+    [MemberData(nameof(AllSeparatorSets))]
+    public void AddGuestSettings_SkipsCommentLines(char[] separators)
     {
-        var settings = Parse("#comment=ignored\nreal=kept", allowSemicolonSeparator);
+        var settings = Parse("#comment=ignored\nreal=kept", separators);
 
         var setting = Assert.Single(settings);
         Assert.Equal("guestinfo.real", setting.Key);
@@ -72,30 +79,55 @@ public class TemplateGuestSettingsTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void AddGuestSettings_DoesNotDoublePrefixAnExplicitGuestinfoKeyInEitherMode(
-        bool allowSemicolonSeparator)
+    [MemberData(nameof(AllSeparatorSets))]
+    public void AddGuestSettings_DoesNotDoublePrefixAnExplicitGuestinfoKey(char[] separators)
     {
-        var settings = Parse("guestinfo.already=1", allowSemicolonSeparator);
+        var settings = Parse("guestinfo.already=1", separators);
 
         Assert.Equal("guestinfo.already", Assert.Single(settings).Key);
     }
 
-    [Theory]
-    [InlineData(HypervisorType.Proxmox, false)]
-    [InlineData(HypervisorType.Vsphere, true)]
-    [InlineData(null, true)]
-    public void AllowsSemicolonGuestSettingSeparator_OptsOutForProxmoxOnly(
-        HypervisorType? hypervisorType, bool expected)
+    // Pins the per-hypervisor contract: only Proxmox excludes ';', because there a ';' reaches the
+    // guest as ordinary value data.
+    [Fact]
+    public void GuestSettingSeparators_ExcludeSemicolonForProxmoxOnly()
     {
-        Assert.Equal(expected, TemplateExtensions.AllowsSemicolonGuestSettingSeparator(hypervisorType));
+        Assert.DoesNotContain(';', ProxmoxHypervisorService.GuestSettingSeparatorSet);
+        Assert.Contains(';', VSphereHypervisorService.GuestSettingSeparatorSet);
+        Assert.Contains(';', MockHypervisorService.GuestSettingSeparatorSet);
     }
 
-    private static VmKeyValue[] Parse(string guestinfo, bool allowSemicolonSeparator)
+    [Fact]
+    public void GuestSettingSeparators_AlwaysIncludeNewlines()
+    {
+        char[][] sets =
+        [
+            ProxmoxHypervisorService.GuestSettingSeparatorSet,
+            VSphereHypervisorService.GuestSettingSeparatorSet,
+            MockHypervisorService.GuestSettingSeparatorSet,
+        ];
+
+        Assert.All(sets, set =>
+        {
+            Assert.Contains('\n', set);
+            Assert.Contains('\r', set);
+        });
+    }
+
+    // Ties the declared set to the parser, so widening Proxmox's separators fails here and not
+    // only in the contract test above.
+    [Fact]
+    public void AddGuestSettings_WithProxmoxSeparators_KeepsASemicolonInTheValue()
+    {
+        var settings = Parse("hosts=a;b", ProxmoxHypervisorService.GuestSettingSeparatorSet);
+
+        Assert.Equal("a;b", Assert.Single(settings).Value);
+    }
+
+    private static VmKeyValue[] Parse(string guestinfo, IReadOnlyList<char> separators)
     {
         var utility = new TemplateUtility("");
-        utility.AddGuestSettings(guestinfo, allowSemicolonSeparator);
+        utility.AddGuestSettings(guestinfo, separators);
         return utility.AsTemplate().GuestSettings;
     }
 }

--- a/src/TopoMojo.Api.Tests/TemplateGuestSettingsTests.cs
+++ b/src/TopoMojo.Api.Tests/TemplateGuestSettingsTests.cs
@@ -1,0 +1,101 @@
+// Copyright 2025 Carnegie Mellon University. All Rights Reserved.
+// Released under a 3 Clause BSD-style license. See LICENSE.md in the project root for license information.
+
+using System.Linq;
+using TopoMojo.Api.Services;
+using TopoMojo.Hypervisor;
+using Xunit;
+
+namespace TopoMojo.Api.Tests;
+
+public class TemplateGuestSettingsTests
+{
+    // On Proxmox a ';' is ordinary data in a Guest Setting value, so splitting on it truncated the
+    // value at the first ';' and leaked the remainder as its own bogus sibling setting.
+    [Theory]
+    [InlineData("hosts=10.7.42.11 web;10.7.42.12 db", "guestinfo.hosts", "10.7.42.11 web;10.7.42.12 db")]
+    [InlineData("dhcp=x=1;y=2", "guestinfo.dhcp", "x=1;y=2")]
+    public void AddGuestSettings_WithoutSemicolonSeparator_KeepsTheWholeValue(
+        string guestinfo, string expectedKey, string expectedValue)
+    {
+        var settings = Parse(guestinfo, allowSemicolonSeparator: false);
+
+        var setting = Assert.Single(settings);
+        Assert.Equal(expectedKey, setting.Key);
+        Assert.Equal(expectedValue, setting.Value);
+    }
+
+    // Pins the legacy vSphere behavior, which is unchanged.
+    [Fact]
+    public void AddGuestSettings_WithSemicolonSeparator_StillSplitsAndDropsTheRemainder()
+    {
+        var settings = Parse("hosts=a;b", allowSemicolonSeparator: true);
+
+        var setting = Assert.Single(settings);
+        Assert.Equal("guestinfo.hosts", setting.Key);
+        Assert.Equal("a", setting.Value);
+    }
+
+    [Fact]
+    public void AddGuestSettings_WithSemicolonSeparator_StillLeaksASiblingKey()
+    {
+        var settings = Parse("dhcp=x=1;y=2", allowSemicolonSeparator: true);
+
+        Assert.Equal(2, settings.Length);
+        Assert.Equal("x=1", settings.Single(x => x.Key == "guestinfo.dhcp").Value);
+        Assert.Equal("2", settings.Single(x => x.Key == "guestinfo.y").Value);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddGuestSettings_SplitsOnNewlinesInEitherMode(bool allowSemicolonSeparator)
+    {
+        var settings = Parse("a=1\nb=2\r\nc=3", allowSemicolonSeparator);
+
+        Assert.Equal(3, settings.Length);
+        Assert.Equal("1", settings.Single(x => x.Key == "guestinfo.a").Value);
+        Assert.Equal("2", settings.Single(x => x.Key == "guestinfo.b").Value);
+        Assert.Equal("3", settings.Single(x => x.Key == "guestinfo.c").Value);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddGuestSettings_SkipsCommentLinesInEitherMode(bool allowSemicolonSeparator)
+    {
+        var settings = Parse("#comment=ignored\nreal=kept", allowSemicolonSeparator);
+
+        var setting = Assert.Single(settings);
+        Assert.Equal("guestinfo.real", setting.Key);
+        Assert.Equal("kept", setting.Value);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddGuestSettings_DoesNotDoublePrefixAnExplicitGuestinfoKeyInEitherMode(
+        bool allowSemicolonSeparator)
+    {
+        var settings = Parse("guestinfo.already=1", allowSemicolonSeparator);
+
+        Assert.Equal("guestinfo.already", Assert.Single(settings).Key);
+    }
+
+    [Theory]
+    [InlineData(HypervisorType.Proxmox, false)]
+    [InlineData(HypervisorType.Vsphere, true)]
+    [InlineData(null, true)]
+    public void AllowsSemicolonGuestSettingSeparator_OptsOutForProxmoxOnly(
+        HypervisorType? hypervisorType, bool expected)
+    {
+        Assert.Equal(expected, TemplateExtensions.AllowsSemicolonGuestSettingSeparator(hypervisorType));
+    }
+
+    private static VmKeyValue[] Parse(string guestinfo, bool allowSemicolonSeparator)
+    {
+        var utility = new TemplateUtility("");
+        utility.AddGuestSettings(guestinfo, allowSemicolonSeparator);
+        return utility.AsTemplate().GuestSettings;
+    }
+}

--- a/src/TopoMojo.Api/AppConstants.cs
+++ b/src/TopoMojo.Api/AppConstants.cs
@@ -29,10 +29,6 @@ namespace TopoMojo.Api
         public const string MarkdownCutLine = "<!-- cut -->";
         public const string TagDelimiter = "#";
         public static char[] StringTokenSeparators = [' ', ',', ';', ':', '|', '\t'];
-        public static char[] StringLineSeparators = [';', '\n', '\r'];
-        // Guest Settings on Proxmox reach the guest through parsers that treat ';' as ordinary
-        // data, so treating it as a separator there truncates values and leaks bogus siblings.
-        public static char[] GuestSettingLineSeparators = ['\n', '\r'];
 
         public const string ErrorListCacheKey = "errbf";
     }

--- a/src/TopoMojo.Api/AppConstants.cs
+++ b/src/TopoMojo.Api/AppConstants.cs
@@ -30,6 +30,9 @@ namespace TopoMojo.Api
         public const string TagDelimiter = "#";
         public static char[] StringTokenSeparators = [' ', ',', ';', ':', '|', '\t'];
         public static char[] StringLineSeparators = [';', '\n', '\r'];
+        // Guest Settings on Proxmox reach the guest through parsers that treat ';' as ordinary
+        // data, so treating it as a separator there truncates values and leaks bogus siblings.
+        public static char[] GuestSettingLineSeparators = ['\n', '\r'];
 
         public const string ErrorListCacheKey = "errbf";
     }

--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
@@ -532,7 +532,7 @@ namespace TopoMojo.Api.Services
                 gamespace.Workspace.HostAffinity,
                 sudo,
                 templates.Select(t => t
-                        .ToVirtualTemplate(gamespace.Id)
+                        .ToVirtualTemplate(gamespace.Id, _pod.AllowsSemicolonGuestSettingSeparator())
                         .SetHostAffinity(gamespace.Workspace.HostAffinity)
                 ).ToArray()
             ), true);

--- a/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
+++ b/src/TopoMojo.Api/Features/Gamespace/GamespaceService.cs
@@ -532,7 +532,7 @@ namespace TopoMojo.Api.Services
                 gamespace.Workspace.HostAffinity,
                 sudo,
                 templates.Select(t => t
-                        .ToVirtualTemplate(gamespace.Id, _pod.AllowsSemicolonGuestSettingSeparator())
+                        .ToVirtualTemplate(gamespace.Id, _pod.GuestSettingSeparators)
                         .SetHostAffinity(gamespace.Workspace.HostAffinity)
                 ).ToArray()
             ), true);

--- a/src/TopoMojo.Api/Features/Template/TemplateExtensions.cs
+++ b/src/TopoMojo.Api/Features/Template/TemplateExtensions.cs
@@ -14,18 +14,11 @@ namespace TopoMojo
     public static class TemplateExtensions
     {
         /// <summary>
-        /// True when ';' should be treated as a Guest Settings separator, which is the legacy
-        /// vSphere behavior. Proxmox delivers ';' to the guest as ordinary data, so splitting on it
-        /// would silently truncate values.
+        /// Projects a template into the form the hypervisor deploys. <paramref name="guestSettingSeparators"/>
+        /// comes from <see cref="IHypervisorService.GuestSettingSeparators"/> and is required, so that
+        /// no hypervisor's Guest Settings syntax is silently assumed.
         /// </summary>
-        public static bool AllowsSemicolonGuestSettingSeparator(this IHypervisorService pod)
-            => AllowsSemicolonGuestSettingSeparator(pod?.Options?.HypervisorType);
-
-        /// <inheritdoc cref="AllowsSemicolonGuestSettingSeparator(IHypervisorService)"/>
-        public static bool AllowsSemicolonGuestSettingSeparator(HypervisorType? hypervisorType)
-            => hypervisorType != HypervisorType.Proxmox;
-
-        public static VmTemplate ToVirtualTemplate(this ConvergedTemplate template, string isolationTag = "", bool allowSemicolonSeparator = true)
+        public static VmTemplate ToVirtualTemplate(this ConvergedTemplate template, string isolationTag, IReadOnlyList<char> guestSettingSeparators)
         {
             TemplateUtility tu = new(template.Detail)
             {
@@ -45,7 +38,7 @@ namespace TopoMojo
                 UseUplinkSwitch = template.WorkspaceUseUplinkSwitch
             };
 
-            tu.AddGuestSettings(template.Guestinfo ?? "", allowSemicolonSeparator);
+            tu.AddGuestSettings(template.Guestinfo ?? "", guestSettingSeparators);
 
             return tu.AsTemplate();
         }

--- a/src/TopoMojo.Api/Features/Template/TemplateExtensions.cs
+++ b/src/TopoMojo.Api/Features/Template/TemplateExtensions.cs
@@ -13,7 +13,19 @@ namespace TopoMojo
 {
     public static class TemplateExtensions
     {
-        public static VmTemplate ToVirtualTemplate(this ConvergedTemplate template, string isolationTag = "")
+        /// <summary>
+        /// True when ';' should be treated as a Guest Settings separator, which is the legacy
+        /// vSphere behavior. Proxmox delivers ';' to the guest as ordinary data, so splitting on it
+        /// would silently truncate values.
+        /// </summary>
+        public static bool AllowsSemicolonGuestSettingSeparator(this IHypervisorService pod)
+            => AllowsSemicolonGuestSettingSeparator(pod?.Options?.HypervisorType);
+
+        /// <inheritdoc cref="AllowsSemicolonGuestSettingSeparator(IHypervisorService)"/>
+        public static bool AllowsSemicolonGuestSettingSeparator(HypervisorType? hypervisorType)
+            => hypervisorType != HypervisorType.Proxmox;
+
+        public static VmTemplate ToVirtualTemplate(this ConvergedTemplate template, string isolationTag = "", bool allowSemicolonSeparator = true)
         {
             TemplateUtility tu = new(template.Detail)
             {
@@ -33,7 +45,7 @@ namespace TopoMojo
                 UseUplinkSwitch = template.WorkspaceUseUplinkSwitch
             };
 
-            tu.AddGuestSettings(template.Guestinfo ?? "");
+            tu.AddGuestSettings(template.Guestinfo ?? "", allowSemicolonSeparator);
 
             return tu.AsTemplate();
         }

--- a/src/TopoMojo.Api/Features/Template/TemplateService.cs
+++ b/src/TopoMojo.Api/Features/Template/TemplateService.cs
@@ -284,7 +284,7 @@ namespace TopoMojo.Api.Services
             ;
 
             return Mapper.Map<ConvergedTemplate>(entity)
-                .ToVirtualTemplate(isolationTag)
+                .ToVirtualTemplate(isolationTag, _pod.AllowsSemicolonGuestSettingSeparator())
                 .SetHostAffinity(entity.Workspace?.HostAffinity ?? false)
             ;
         }

--- a/src/TopoMojo.Api/Features/Template/TemplateService.cs
+++ b/src/TopoMojo.Api/Features/Template/TemplateService.cs
@@ -284,7 +284,7 @@ namespace TopoMojo.Api.Services
             ;
 
             return Mapper.Map<ConvergedTemplate>(entity)
-                .ToVirtualTemplate(isolationTag, _pod.AllowsSemicolonGuestSettingSeparator())
+                .ToVirtualTemplate(isolationTag, _pod.GuestSettingSeparators)
                 .SetHostAffinity(entity.Workspace?.HostAffinity ?? false)
             ;
         }

--- a/src/TopoMojo.Api/Features/Template/TemplateUtility.cs
+++ b/src/TopoMojo.Api/Features/Template/TemplateUtility.cs
@@ -121,15 +121,25 @@ namespace TopoMojo.Api.Services
             set { _template.GuestSettings = value; }
         }
 
-        public void AddGuestSettings(string guestinfo)
+        /// <param name="guestinfo">The raw Guest Settings text, one <c>key=value</c> per line.</param>
+        /// <param name="allowSemicolonSeparator">
+        /// When true (the legacy behavior, used by vSphere), ';' separates settings in addition to
+        /// newlines. Proxmox passes ';' through to the guest as ordinary data, so it must opt out
+        /// to avoid truncating a value at the first ';' and leaking the remainder as its own key.
+        /// </param>
+        public void AddGuestSettings(string guestinfo, bool allowSemicolonSeparator = true)
         {
             var result = new List<VmKeyValue>();
 
             if (_template.GuestSettings != null)
                 result.AddRange(_template.GuestSettings);
 
+            var separators = allowSemicolonSeparator
+                ? AppConstants.StringLineSeparators
+                : AppConstants.GuestSettingLineSeparators;
+
             var lines = guestinfo?.Split(
-                AppConstants.StringLineSeparators,
+                separators,
                 StringSplitOptions.RemoveEmptyEntries
             ) ?? [];
 

--- a/src/TopoMojo.Api/Features/Template/TemplateUtility.cs
+++ b/src/TopoMojo.Api/Features/Template/TemplateUtility.cs
@@ -122,24 +122,20 @@ namespace TopoMojo.Api.Services
         }
 
         /// <param name="guestinfo">The raw Guest Settings text, one <c>key=value</c> per line.</param>
-        /// <param name="allowSemicolonSeparator">
-        /// When true (the legacy behavior, used by vSphere), ';' separates settings in addition to
-        /// newlines. Proxmox passes ';' through to the guest as ordinary data, so it must opt out
-        /// to avoid truncating a value at the first ';' and leaking the remainder as its own key.
+        /// <param name="separators">
+        /// The characters that end one setting and begin the next, as declared by the target
+        /// hypervisor in <see cref="IHypervisorService.GuestSettingSeparators"/>. A separator cannot
+        /// appear literally in a value, so this set is never widened here.
         /// </param>
-        public void AddGuestSettings(string guestinfo, bool allowSemicolonSeparator = true)
+        public void AddGuestSettings(string guestinfo, IReadOnlyList<char> separators)
         {
             var result = new List<VmKeyValue>();
 
             if (_template.GuestSettings != null)
                 result.AddRange(_template.GuestSettings);
 
-            var separators = allowSemicolonSeparator
-                ? AppConstants.StringLineSeparators
-                : AppConstants.GuestSettingLineSeparators;
-
             var lines = guestinfo?.Split(
-                separators,
+                [.. separators],
                 StringSplitOptions.RemoveEmptyEntries
             ) ?? [];
 

--- a/src/TopoMojo.Api/Features/Workspace/WorkspaceService.cs
+++ b/src/TopoMojo.Api/Features/Workspace/WorkspaceService.cs
@@ -288,7 +288,7 @@ namespace TopoMojo.Api.Services
             {
 
                 var disktasks = Mapper.Map<ConvergedTemplate[]>(templates)
-                    .Select(ct => _pod.DeleteDisks(ct.ToVirtualTemplate()))
+                    .Select(ct => _pod.DeleteDisks(ct.ToVirtualTemplate("", _pod.GuestSettingSeparators)))
                     .ToArray()
                 ;
 

--- a/src/TopoMojo.Hypervisor.Tests/ProxmoxFwCfgTests.cs
+++ b/src/TopoMojo.Hypervisor.Tests/ProxmoxFwCfgTests.cs
@@ -1,0 +1,273 @@
+// Copyright 2025 Carnegie Mellon University. All Rights Reserved.
+// Released under a 3 Clause BSD-style license. See LICENSE.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TopoMojo.Hypervisor.Proxmox;
+using Xunit;
+
+namespace TopoMojo.Hypervisor.Tests;
+
+public class ProxmoxFwCfgTests
+{
+    // Values that previously broke, plus edge cases around the two escapes.
+    // The expected round-trip results were produced by driving this escaping through the real
+    // Proxmox parser (perl Text::ParseWords::shellwords, which PVE::Tools::split_args uses) and a
+    // QemuOpts comma reducer, so ParseArgs below is checked against known-good output.
+    public static TheoryData<string> RoundTripValues =>
+    [
+        "dhcp-range=10.7.42.50,10.7.42.150,12h",
+        @"C:\Users\bob",
+        "he said \"hi\"",
+        "10.7.42.11 web",
+        "hosts=a;b",
+        "it's a,b",
+        "trailing,",
+        ",,already doubled",
+        "plain",
+    ];
+
+    [Theory]
+    [MemberData(nameof(RoundTripValues))]
+    public void Arg_DeliversTheValueToTheGuestUnchanged(string value)
+    {
+        var parsed = ParseArgs(ProxmoxFwCfg.Arg("guestinfo.setting", value));
+
+        var fwCfg = Assert.Single(parsed);
+        Assert.Equal("opt/guestinfo.setting", fwCfg["name"]);
+        Assert.Equal(value, fwCfg["string"]);
+    }
+
+    [Theory]
+    [MemberData(nameof(RoundTripValues))]
+    public void Arg_DeliversTheKeyToTheGuestUnchanged(string key)
+    {
+        var parsed = ParseArgs(ProxmoxFwCfg.Arg(key, "value"));
+
+        var fwCfg = Assert.Single(parsed);
+        Assert.Equal($"opt/{key}", fwCfg["name"]);
+        Assert.Equal("value", fwCfg["string"]);
+    }
+
+    [Fact]
+    public void Arg_DoublesCommasAndSingleQuotesTheWholeArgument()
+    {
+        // Quoting cannot protect a comma, because Proxmox strips quotes before QemuOpts splits on
+        // commas. Both escapes are applied, and single quotes are used so backslashes survive.
+        Assert.Equal(
+            @"-fw_cfg 'name=opt/guestinfo.dhcp,string=10.7.42.50,,10.7.42.150,,12h'",
+            ProxmoxFwCfg.Arg("guestinfo.dhcp", "10.7.42.50,10.7.42.150,12h"));
+
+        Assert.Equal(
+            @"-fw_cfg 'name=opt/guestinfo.p,string=C:\Users\bob'",
+            ProxmoxFwCfg.Arg("guestinfo.p", @"C:\Users\bob"));
+
+        Assert.Equal(
+            @"-fw_cfg 'name=opt/guestinfo.q,string=it'\''s'",
+            ProxmoxFwCfg.Arg("guestinfo.q", "it's"));
+    }
+
+    [Theory]
+    [InlineData("a\nb")]
+    [InlineData("a\rb")]
+    public void Arg_FoldsNewlinesThatWouldCorruptTheProxmoxConfigFile(string value)
+    {
+        var arg = ProxmoxFwCfg.Arg("guestinfo.setting", value);
+
+        Assert.DoesNotContain('\n', arg);
+        Assert.DoesNotContain('\r', arg);
+        Assert.Equal("a b", Assert.Single(ParseArgs(arg))["string"]);
+    }
+
+    [Fact]
+    public void Arg_TreatsANullValueAsEmpty()
+    {
+        Assert.Equal(
+            "-fw_cfg 'name=opt/guestinfo.setting,string='",
+            ProxmoxFwCfg.Arg("guestinfo.setting", null));
+    }
+
+    [Fact]
+    public void GetArgs_ReturnsNullWhenThereAreNoGuestSettings()
+    {
+        Assert.Null(ProxmoxClient.GetArgs(new VmTemplate { GuestSettings = null }));
+        Assert.Null(ProxmoxClient.GetArgs(new VmTemplate { GuestSettings = [] }));
+    }
+
+    [Fact]
+    public void GetArgs_EmitsTheDefaultSettingsAndEscapesEachSetting()
+    {
+        var template = new VmTemplate
+        {
+            Name = "web#abc123",
+            Id = "template-id",
+            IsolationTag = "abc123",
+            GuestSettings =
+            [
+                new VmKeyValue { Key = "guestinfo.dhcp", Value = "10.7.42.50,10.7.42.150,12h" },
+                new VmKeyValue { Key = "guestinfo.hosts", Value = "10.7.42.11 web" },
+            ]
+        };
+
+        var parsed = ParseArgs(ProxmoxClient.GetArgs(template));
+
+        Assert.Equal(5, parsed.Count);
+        Assert.Equal("abc123", Find(parsed, "opt/guestinfo.isolationTag"));
+        Assert.Equal("template-id", Find(parsed, "opt/guestinfo.templateSource"));
+        Assert.Equal("web", Find(parsed, "opt/guestinfo.hostname"));
+        Assert.Equal("10.7.42.50,10.7.42.150,12h", Find(parsed, "opt/guestinfo.dhcp"));
+        Assert.Equal("10.7.42.11 web", Find(parsed, "opt/guestinfo.hosts"));
+    }
+
+    [Fact]
+    public void GetArgs_StillSkipsIftagSettingsForOtherIsolations()
+    {
+        var template = new VmTemplate
+        {
+            Name = "web#abc123",
+            Id = "template-id",
+            IsolationTag = "abc123",
+            GuestSettings =
+            [
+                new VmKeyValue { Key = "iftag.mine", Value = "abc123:on" },
+                new VmKeyValue { Key = "iftag.theirs", Value = "def456:on" },
+            ]
+        };
+
+        var parsed = ParseArgs(ProxmoxClient.GetArgs(template));
+
+        Assert.Equal("abc123:on", Find(parsed, "opt/iftag.mine"));
+        Assert.DoesNotContain(parsed, x => x["name"] == "opt/iftag.theirs");
+    }
+
+    private static string Find(List<Dictionary<string, string>> parsed, string name)
+        => parsed.Single(x => x["name"] == name)["string"];
+
+    /// <summary>
+    /// Replays the two parsers an <c>args</c> string traverses on its way to the guest, so a test
+    /// can assert on what the guest actually reads rather than on the escaping itself.
+    /// </summary>
+    private static List<Dictionary<string, string>> ParseArgs(string args)
+    {
+        var argv = Shellwords(args);
+        var result = new List<Dictionary<string, string>>();
+
+        for (int i = 0; i < argv.Count; i++)
+        {
+            if (argv[i] != "-fw_cfg")
+                continue;
+
+            Assert.True(i + 1 < argv.Count, "-fw_cfg with no argument");
+            result.Add(QemuOpts(argv[++i]));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Mirrors Text::ParseWords::shellwords, which PVE::Tools::split_args uses to turn the vm's
+    /// <c>args</c> property into argv. Quotes group and are then stripped; single quotes are
+    /// literal, while a backslash escapes the next character outside of them.
+    /// </summary>
+    private static List<string> Shellwords(string input)
+    {
+        var words = new List<string>();
+        var current = new StringBuilder();
+        bool started = false;
+        char quote = '\0';
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            char c = input[i];
+
+            if (quote == '\'')
+            {
+                if (c == '\'')
+                    quote = '\0';
+                else
+                    current.Append(c);
+            }
+            else if (quote == '"')
+            {
+                if (c == '"')
+                    quote = '\0';
+                else if (c == '\\' && i + 1 < input.Length)
+                    current.Append(input[++i]);
+                else
+                    current.Append(c);
+            }
+            else if (c is '\'' or '"')
+            {
+                quote = c;
+                started = true;
+            }
+            else if (c == '\\' && i + 1 < input.Length)
+            {
+                current.Append(input[++i]);
+                started = true;
+            }
+            else if (char.IsWhiteSpace(c))
+            {
+                if (started)
+                    words.Add(current.ToString());
+
+                current.Clear();
+                started = false;
+            }
+            else
+            {
+                current.Append(c);
+                started = true;
+            }
+        }
+
+        Assert.Equal('\0', quote); // an unbalanced quote makes shellwords drop everything
+
+        if (started)
+            words.Add(current.ToString());
+
+        return words;
+    }
+
+    /// <summary>
+    /// Mirrors QEMU's QemuOpts parser: split one argv element on single commas, collapsing a
+    /// doubled comma to a literal one, then split each token on its first '='.
+    /// </summary>
+    private static Dictionary<string, string> QemuOpts(string element)
+    {
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+
+        for (int i = 0; i < element.Length; i++)
+        {
+            if (element[i] != ',')
+            {
+                current.Append(element[i]);
+            }
+            else if (i + 1 < element.Length && element[i + 1] == ',')
+            {
+                current.Append(',');
+                i++;
+            }
+            else
+            {
+                tokens.Add(current.ToString());
+                current.Clear();
+            }
+        }
+
+        tokens.Add(current.ToString());
+
+        var options = new Dictionary<string, string>();
+
+        foreach (var token in tokens)
+        {
+            int split = token.IndexOf('=');
+            Assert.True(split > 0, $"QemuOpts would reject '{token}' as an invalid parameter");
+            options[token[..split]] = token[(split + 1)..];
+        }
+
+        return options;
+    }
+}

--- a/src/TopoMojo.Hypervisor/IHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/IHypervisorService.cs
@@ -38,6 +38,13 @@ namespace TopoMojo.Hypervisor
         Task ReloadHost(string host);
         HypervisorServiceConfiguration Options { get; }
         /// <summary>
+        /// Characters that separate one Guest Setting from the next in a template's Guest Settings
+        /// text. Every hypervisor separates on newlines; some also accept another character. A
+        /// separator cannot appear literally in a value, so each hypervisor declares only what its
+        /// own authoring syntax supports.
+        /// </summary>
+        IReadOnlyList<char> GuestSettingSeparators { get; }
+        /// <summary>
         /// Path, relative to the ISO store root, where an ISO for the given scope must be written.
         /// Stores with per-scope folders return "{scopeId}/{fileName}"; flat stores return a single
         /// filename with the scope encoded into it. The hypervisor owns storage layout and filename

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxClient.cs
@@ -1064,18 +1064,19 @@ namespace TopoMojo.Hypervisor.Proxmox
             return nodes.ElementAt(randomNum).Node;
         }
 
-        private static string GetArgs(VmTemplate template)
+        internal static string GetArgs(VmTemplate template)
         {
-            if (template.GuestSettings.Length == 0)
+            if (template.GuestSettings is null || template.GuestSettings.Length == 0)
                 return null;
-
-            var args = new StringBuilder();
 
             // Default settings
             // TODO: Fix duplication with vsphere?
-            args.Append($"-fw_cfg name=opt/guestinfo.isolationTag,string=\"{template.IsolationTag}\" ");
-            args.Append($"-fw_cfg name=opt/guestinfo.templateSource,string=\"{template.Id}\" ");
-            args.Append($"-fw_cfg name=opt/guestinfo.hostname,string=\"{template.Name.Untagged()}\" ");
+            var args = new List<string>
+            {
+                ProxmoxFwCfg.Arg("guestinfo.isolationTag", template.IsolationTag),
+                ProxmoxFwCfg.Arg("guestinfo.templateSource", template.Id),
+                ProxmoxFwCfg.Arg("guestinfo.hostname", template.Name.Untagged()),
+            };
 
             foreach (var setting in template.GuestSettings)
             {
@@ -1085,10 +1086,10 @@ namespace TopoMojo.Hypervisor.Proxmox
                     continue;
                 }
 
-                args.Append($"-fw_cfg name=opt/{setting.Key},string=\"{setting.Value}\" ");
+                args.Add(ProxmoxFwCfg.Arg(setting.Key, setting.Value));
             }
 
-            return args.ToString().TrimEnd();
+            return string.Join(" ", args);
         }
 
         private async Task<string> GetIso(VmTemplate template)

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxFwCfg.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxFwCfg.cs
@@ -1,0 +1,53 @@
+// Copyright 2025 Carnegie Mellon University. All Rights Reserved.
+// Released under a 3 Clause BSD-style license. See LICENSE.md in the project root for license information.
+
+namespace TopoMojo.Hypervisor.Proxmox
+{
+    /// <summary>
+    /// Builds the <c>-fw_cfg</c> arguments used to deliver Guest Settings to a Proxmox vm.
+    /// </summary>
+    /// <remarks>
+    /// The generated text is stored in the vm's <c>args</c> property, and reaches the guest only
+    /// after passing through two independent parsers that must each be escaped for:
+    /// <list type="number">
+    /// <item>
+    /// Proxmox splits <c>args</c> into argv with <c>PVE::Tools::split_args</c>, which is
+    /// <c>Text::ParseWords::shellwords</c>. It honours quotes and then strips them.
+    /// </item>
+    /// <item>
+    /// QEMU parses one argv element with <c>QemuOpts</c>, which splits on commas. It has no quote
+    /// handling at all, so quoting cannot protect a comma; its only escape is a doubled comma,
+    /// which it collapses again before the guest reads the value.
+    /// </item>
+    /// </list>
+    /// Because the layers do not meet, both escapes are always required.
+    /// </remarks>
+    internal static class ProxmoxFwCfg
+    {
+        /// <summary>
+        /// Builds one complete, fully escaped <c>-fw_cfg</c> argument for a Guest Setting.
+        /// </summary>
+        internal static string Arg(string key, string value)
+            => $"-fw_cfg {ShellQuote($"name=opt/{Opts(key)},string={Opts(value)}")}";
+
+        /// <summary>
+        /// Escapes for QEMU's QemuOpts parser by doubling every literal comma. QEMU collapses the
+        /// doubling before the guest reads the value, so it is invisible to guests and lab authors.
+        /// Carriage returns and line feeds are folded to a space because a newline would corrupt
+        /// the Proxmox vm config file.
+        /// </summary>
+        private static string Opts(string value)
+            => (value ?? string.Empty)
+                .Replace("\r", " ")
+                .Replace("\n", " ")
+                .Replace(",", ",,");
+
+        /// <summary>
+        /// Escapes for Proxmox's shellwords parser. Single quotes are used rather than double
+        /// quotes because they preserve backslashes and are unaffected by a double quote in the
+        /// value. An embedded single quote closes, escapes, and reopens the quoted run.
+        /// </summary>
+        private static string ShellQuote(string value)
+            => $"'{value.Replace("'", @"'\''")}'";
+    }
+}

--- a/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/Proxmox/ProxmoxHypervisorService.cs
@@ -55,6 +55,13 @@ namespace TopoMojo.Hypervisor.Proxmox
         private readonly IProxmoxVlanManager _vlanManager;
 
         public HypervisorServiceConfiguration Options { get { return _options; } }
+
+        // Newlines only. Proxmox delivers Guest Settings to the guest as ordinary data, so a ';'
+        // is a legitimate value character; treating it as a separator would truncate the value at
+        // the first ';' and leak the remainder as its own setting.
+        public static readonly char[] GuestSettingSeparatorSet = ['\n', '\r'];
+        public IReadOnlyList<char> GuestSettingSeparators => GuestSettingSeparatorSet;
+
         private readonly BlockingCollection<DeploymentContext> DeploymentCollection = [];
 
 

--- a/src/TopoMojo.Hypervisor/vMock/MockHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/vMock/MockHypervisorService.cs
@@ -41,6 +41,10 @@ namespace TopoMojo.Hypervisor.vMock
 
         public HypervisorServiceConfiguration Options { get { return _optPod; } }
 
+        // The mock stands in for a vSphere-like host, so it accepts the same separators.
+        public static readonly char[] GuestSettingSeparatorSet = [';', '\n', '\r'];
+        public IReadOnlyList<char> GuestSettingSeparators => GuestSettingSeparatorSet;
+
         public Task StartAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;

--- a/src/TopoMojo.Hypervisor/vSphere/vSphereHypervisorService.cs
+++ b/src/TopoMojo.Hypervisor/vSphere/vSphereHypervisorService.cs
@@ -49,6 +49,12 @@ namespace TopoMojo.Hypervisor.vSphere
         private readonly BlockingCollection<DeploymentContext> DeploymentCollection = [];
         public HypervisorServiceConfiguration Options { get { return _options; } }
 
+        // vSphere carries Guest Settings in the virtual machine's ExtraConfig, where a ';' has no
+        // meaning to any parser in the path, so its authoring syntax accepts ';' as a separator in
+        // addition to newlines.
+        public static readonly char[] GuestSettingSeparatorSet = [';', '\n', '\r'];
+        public IReadOnlyList<char> GuestSettingSeparators => GuestSettingSeparatorSet;
+
         public async Task ReloadHost(string hostname)
         {
             string host = "https://" + hostname + "/sdk";


### PR DESCRIPTION
## Summary

Fix Proxmox Guest Settings that were truncated or misparsed when values contained punctuation or shell-sensitive characters. Values now pass through Proxmox and QEMU unchanged, so settings such as DHCP ranges, host lists, Windows paths, and quoted text work as entered.

## User-facing changes

- Proxmox Guest Settings values containing commas now work. For example, a value such as `dhcp-range=10.7.42.50,10.7.42.150,12h` is delivered as one setting instead of being split into multiple QEMU options.
- Values containing backslashes, quotes, and spaces now arrive in the guest as written, so paths such as `C:\Users\bob` and text such as `he said "hi"` no longer need special manual escaping.
- Semicolons in Proxmox values now remain part of the value. For example, `hosts=web;db` is kept intact instead of being split into separate settings.
- Additional `=` characters in a value continue to work, such as `dhcp=x=1;y=2` on Proxmox.
- vSphere and the mock hypervisor retain semicolon-separated authoring support.
- Proxmox Guest Settings documentation now describes the supported value syntax and escaping behavior.

## Technical details

- Added dedicated Proxmox `fw_cfg` argument escaping for Proxmox shell-word parsing and QEMU comma-delimited option parsing.
- Made Guest Settings separators an explicit hypervisor capability and passed that capability through template conversion.
- Added parser round-trip and hypervisor separator tests.
- Validation: full solution test suite passes with 86 tests.
